### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM node
+WORKDIR /app
+COPY . .
+RUN npm install
+RUN npm install webpack typescript jquery
+ENTRYPOINT ["./start.sh"]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,18 @@ This repository does not contain game books data. Data must be downloaded from t
 
 ## Setup
 
+### Docker
+You can run the server within a docker container if you wish. First, pull the image:
+```
+docker pull samtebbs33/kaichronicles:latest
+```
+Then run it, substituting the host port (the port before the colon) for a one of your choice.
+```
+docker run -p 3000:3000 samtebbs33/kaichronicles:latest
+```
+The server will then be accessible at http://localhost:3000 (replace with the chosen host port, if necessary).
+
+### Manual
 Download dependencies
 ```bash
 npm install

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+npm run downloaddata
+npm run serve


### PR DESCRIPTION
This PR adds a Dockerfile so that the server can be run within a docker container, for easy deployment in a home server. The resulting docker image doesn't store any of the game data so Project Aon's licence isn't broken.

I have pushed the image to my own docker repository on docker hub and am happy to continue hosting it there, but understand if you'd like to host it yourself.