### PR TITLE
Fix for mentalOnly battle

### DIFF
--- a/src/ts/controller/mechanics/mechanicsEngine.ts
+++ b/src/ts/controller/mechanics/mechanicsEngine.ts
@@ -980,7 +980,7 @@ export const mechanicsEngine = {
         }
 
         // Check if the combat is non-physical (disables most bonuses)
-        combat.mentalOnly = mechanicsEngine.getBooleanProperty($rule, "mentalOnly", false);
+        combat.mentalOnly = mechanicsEngine.getBooleanProperty($rule, "mentalOnly", combat.mentalOnly);
 
         // Initial turn to allow to elude the combat
         if ($rule.attr("eludeTurn")) {


### PR DESCRIPTION
MentalOnly isn't working, since there are <combat> tags that follow it and reset it to false.  This takes the default from the already set value (as done above for other modifiers like combat.noMindblast)

Fixes #13