### PR TITLE
Fix for not dropping the deathstaff at the end of book 16

### DIFF
--- a/www/data/mechanics-16.xml
+++ b/www/data/mechanics-16.xml
@@ -2308,7 +2308,7 @@
             </test>
         </section>
 
-        <section id="350">
+        <section id="sect350">
             <drop objectId="deathstaff" />
         </section>
 

--- a/www/data/mechanics-20.xml
+++ b/www/data/mechanics-20.xml
@@ -1430,7 +1430,7 @@
             </afterCombats>
         </section>
 
-        <section id="199">
+        <section id="sect199">
             <endurance count="-2" />
         </section>
 


### PR DESCRIPTION
Also searched for similar issues and corrected similar error in book 20

Resolves #28 