### PR TITLE
Book 21 Implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Kai Chronicles
 
-Kai Chronicles is a game player for Lone Wolf game books. Books 1 - 20 are playable. The game player can run as a website.
+Kai Chronicles is a game player for Lone Wolf game books. Books 1 - 21 are playable. The game player can run as a website.
 
 This is a fork from the [original "Kai Chronicles"](https://github.com/tonib/kaichronicles) as tonib stopped development in November 2021.
 

--- a/doc/README-mechanics.md
+++ b/doc/README-mechanics.md
@@ -303,7 +303,7 @@ Make an object available on the section. The player will can pick / buy it.
 * **price**: If it's set, the price to buy the object (not free)
 * **unlimited="true"**: There is an unlimited number of objects of this class on the section
 * **index="number"** Required, for ugly reasons, when there are two o more objects with the same object id on a section
-* **useOnSection="true"**: If true, the player will can use the object without picking it
+* **useOnSection="true"**: If true, the player will use the object without picking it
 
 ### tag
 ```xml

--- a/doc/README-mechanics.md
+++ b/doc/README-mechanics.md
@@ -302,7 +302,7 @@ Make an object available on the section. The player will can pick / buy it.
 * **objectId**: The available object id 
 * **price**: If it's set, the price to buy the object (not free)
 * **unlimited="true"**: There is an unlimited number of objects of this class on the section
-* **index="number"** Required, for ugly reasons, when there are two o more objects with the same object id on a section
+* **index="number"** Required, for ugly reasons, when there are two or more objects with the same object id on a section
 * **useOnSection="true"**: If true, the player will use the object without picking it
 
 ### tag

--- a/doc/README-mechanics.md
+++ b/doc/README-mechanics.md
@@ -327,7 +327,7 @@ This will allow to the player to sell a class of objects by a given price
 ```xml
 <resetSectionState sectionId="sect152" />
 ```
-This will clear the state of the given section. Usefull if the player can return to that
+This will clear the state of the given section. Useful if the player can return to that
 section, and there are rules with state there that must to be reexecuted
 
 ### meal

--- a/src/ts/controller/actionChartController.ts
+++ b/src/ts/controller/actionChartController.ts
@@ -440,6 +440,21 @@ export const actionChartController = {
 
     },
 
+    /**
+     * Increase / decrease the current endurance restored in the book
+     * @param count Number to increase. Negative to decrease
+     */
+    increaseNewOrderCuringEPRestored(count: number) {
+        this.newOrderCuringEPRestored += count;
+    },
+
+    /**
+     * Get the current endurance restored in the book
+     */
+    getNewOrderCuringEPRestored() : number {
+        return this.newOrderCuringEPRestored;
+    },
+
     /** Set the current endurance, just for debug */
     setEndurance(endurance: number) {
         actionChartController.increaseEndurance(endurance - state.actionChart.currentEndurance);

--- a/src/ts/controller/actionChartController.ts
+++ b/src/ts/controller/actionChartController.ts
@@ -445,14 +445,14 @@ export const actionChartController = {
      * @param count Number to increase. Negative to decrease
      */
     increaseNewOrderCuringEPRestored(count: number) {
-        this.newOrderCuringEPRestored += count;
+        state.actionChart.newOrderCuringEPRestored += count;
     },
 
     /**
      * Get the current endurance restored in the book
      */
     getNewOrderCuringEPRestored() : number {
-        return this.newOrderCuringEPRestored;
+        return state.actionChart.newOrderCuringEPRestored;
     },
 
     /** Set the current endurance, just for debug */

--- a/src/ts/controller/actionChartController.ts
+++ b/src/ts/controller/actionChartController.ts
@@ -211,6 +211,7 @@ export const actionChartController = {
 
             // Update the action chart view
             actionChartView.updateObjectsLists();
+            actionChartView.fillKaiWeapon(state.actionChart);
 
             // Update player statistics (for objects with effects)
             actionChartView.updateStatistics();

--- a/src/ts/controller/gameController.ts
+++ b/src/ts/controller/gameController.ts
@@ -43,6 +43,7 @@ export const gameController = {
     /** Setup the HTML main page template for the game view */
     gameTemplateSetup() {
         template.showStatistics(true);
+        template.showKaiName(state.actionChart.kaiName !== "");
         template.setNavTitle(state.book.getBookTitle(), "#game", false);
     },
 

--- a/src/ts/controller/loadGameController.ts
+++ b/src/ts/controller/loadGameController.ts
@@ -13,6 +13,7 @@ export class loadGameController {
     public static index() {
         template.setNavTitle( translations.text("kaiChronicles"), "#mainMenu", true);
         template.showStatistics(false);
+        template.showKaiName(false);
         views.loadView("loadGame.html").then(() => {
             // Web page environment:
             loadGameView.bindFileUploaderEvents();

--- a/src/ts/controller/mainMenuController.ts
+++ b/src/ts/controller/mainMenuController.ts
@@ -11,6 +11,7 @@ export const mainMenuController = {
     index() {
         template.setNavTitle( translations.text("kaiChronicles") , "#mainMenu", true);
         template.showStatistics(false);
+        template.showKaiName(false);
         views.loadView("mainMenu.html").then(() => {
             mainMenuView.setup();
 

--- a/src/ts/controller/mechanics/equipmentSectionMechanics.ts
+++ b/src/ts/controller/mechanics/equipmentSectionMechanics.ts
@@ -104,6 +104,7 @@ export class EquipmentSectionMechanics {
             $("#mechanics-chooseEquipment").hide();
             gameView.enableNextLink(true);
         }
+
     }
 
     /**
@@ -111,11 +112,29 @@ export class EquipmentSectionMechanics {
      * @returns An object. Key is the object id and the value is the number of objects
      */
     private static getOriginalObjects( $sectionMechanics: JQuery<Element> ): { [objectId: string ]: number } {
-
         // Get the original objects on the section:
         const childrenRules = $sectionMechanics.children();
         const originalObjects = {};
         for (const rule of childrenRules.toArray()) {
+            // Also process test tag for sectionVisited - if other tests are needed this should be rewritten to share existing logic
+            if ( rule.nodeName === "test" ) {
+                // Check section visited:
+                const sectionIdsList = mechanicsEngine.getArrayProperty($(rule), "sectionVisited");
+                const invertCondition = mechanicsEngine.getArrayProperty($(rule), "not")[0] === "true";
+                for (const sectionId of sectionIdsList) {
+                    if ((state.sectionStates.sectionIsVisited(sectionId) && !invertCondition)
+                        || (!state.sectionStates.sectionIsVisited(sectionId) && invertCondition)) {
+                        const subItemObjects = this.getOriginalObjects($(rule));
+                        for(const objectid in subItemObjects) {
+                            if ( !originalObjects[objectid] ) {
+                                originalObjects[objectid] = 1;
+                            } else {
+                                originalObjects[objectid] += 1;
+                            }
+                        }
+                    }
+                }
+            }
             if ( rule.nodeName === "object" ) {
                 const objectid = $(rule).attr("objectId");
                 if ( !originalObjects[objectid] ) {

--- a/src/ts/controller/mechanics/equipmentSectionMechanics.ts
+++ b/src/ts/controller/mechanics/equipmentSectionMechanics.ts
@@ -104,7 +104,6 @@ export class EquipmentSectionMechanics {
             $("#mechanics-chooseEquipment").hide();
             gameView.enableNextLink(true);
         }
-
     }
 
     /**

--- a/src/ts/controller/mechanics/kaiNameSetup.ts
+++ b/src/ts/controller/mechanics/kaiNameSetup.ts
@@ -6,65 +6,72 @@ import { state, template, gameView, mechanicsEngine, BookSeriesId, randomMechani
 export class KaiNameSetup {
 
     /**
-     * Weapons table for Weaponskill discipline in Kai books (IT DOES NOT CONTAIN BOW!!!)
+     * First names
      */
     public static readonly firstNames = ["Swift", "Sun", "True", "Bold", "Moon", "Sword",
             "Wise", "Storm", "Rune", "Brave"];
 
     /**
-     * Weapons table for Weaponskill discipline in Kai books (IT DOES NOT CONTAIN BOW!!!)
+     * Last names
      */
     public static readonly lastNames = ["Blade", "Fire", "Hawk", "Heart", "Friend", "Star",
         "Dancer", "Helm", "Strider", "Shield"];
 
     /**
-     * Choose player skills UI
+     * Choose Kai name UI
      */
     public static setKaiName() {
-        // If the name is already set or not a New Order book, do nothing
-        if (state.book.getBookSeries().id != BookSeriesId.NewOrder || state.actionChart.kaiName !== "") {
+        // Add HTML to do the choice
+        gameView.appendToSection(mechanicsEngine.getMechanicsUI("mechanics-setKaiName"));
+
+        // Prefill the text area with the existing name
+        $("#mechanics-customKaiName").val(state.actionChart.kaiName);
+        
+        // If the name is already set show the name
+        if (state.actionChart.kaiName !== "") {
+            $("#kaiName").append("<b>" + state.actionChart.kaiName + "</b>");
+            $("#mechanics-setNames").hide();
             return;
         }
-
-        // Add HTML to do the choose
-        gameView.appendToSection(mechanicsEngine.getMechanicsUI("mechanics-setKaiName"));
+        else {
+            $("#mechanics-existingKaiName").hide();
+        }
 
         // Disable next link
         gameView.enableNextLink(false);
 
         // Kai Name
-        if (state.actionChart.kaiName !== "") {
-            $("#mechanics-detFirstName").hide();
-            $("#mechanics-detLastName").hide();
-        } else {
+        if (state.actionChart.kaiName === "") {
+            $("#mechanics-customKaiName").on("input", (e) => {
+                state.actionChart.kaiName = $("#mechanics-customKaiName").val().toString();
+                gameView.enableNextLink($("#mechanics-customKaiName").val() !== "");
+                template.updateKaiName();
+            });
+
             const $f = $("#mechanics-chooseFirstName");
             randomMechanics.bindTableRandomLink($f, (value) => {
-                if (state.actionChart.kaiName !== "") {
-                    state.actionChart.kaiName = this.firstNames[value] + " " + state.actionChart.kaiName;
+                if ($("#mechanics-customKaiName").prop('readonly')) {
+                    $("#mechanics-customKaiName").val(this.firstNames[value] + " " + $("#mechanics-customKaiName").val());
                 }
                 else {
-                    state.actionChart.kaiName = this.firstNames[value];
+                    $("#mechanics-customKaiName").val(this.firstNames[value]);
+                    $("#mechanics-customKaiName").prop('readonly', true);
                 }
-                $f.parent().append("<b>" + translations.text("firstNameSet", [this.firstNames[value]]) + ".</b>");
-                template.updateKaiName();
-                if (state.actionChart.kaiName.includes(" ")) {
-                    gameView.enableNextLink(true);
-                }
+
+                $("#mechanics-customKaiName").trigger("input");
             }, false);
 
             const $l = $("#mechanics-chooseLastName");
             randomMechanics.bindTableRandomLink($l, (value) => {
-                if (state.actionChart.kaiName !== "") {
-                    state.actionChart.kaiName = state.actionChart.kaiName + " " + this.lastNames[value];
+                if ($("#mechanics-customKaiName").prop('readonly')) {
+                    $("#mechanics-customKaiName").val($("#mechanics-customKaiName").val() + " " + this.lastNames[value]);
                 }
                 else {
-                    state.actionChart.kaiName = this.lastNames[value];
+                    $("#mechanics-customKaiName").val(this.lastNames[value]);
+                    $("#mechanics-customKaiName").prop('readonly', true);
                 }
-                $l.parent().append("<b>" + translations.text("lastNameSet", [this.lastNames[value]]) + ".</b>");
-                template.updateKaiName();
-                if (state.actionChart.kaiName.includes(" ")) {
-                    gameView.enableNextLink(true);
-                }
+
+                $("#mechanics-customKaiName").trigger("input");
             }, false);
         }
     }

--- a/src/ts/controller/mechanics/kaiNameSetup.ts
+++ b/src/ts/controller/mechanics/kaiNameSetup.ts
@@ -1,0 +1,71 @@
+import { state, template, gameView, mechanicsEngine, BookSeriesId, randomMechanics, translations, BookSeries } from "../..";
+
+/**
+ * Kai name setup
+ */
+export class KaiNameSetup {
+
+    /**
+     * Weapons table for Weaponskill discipline in Kai books (IT DOES NOT CONTAIN BOW!!!)
+     */
+    public static readonly firstNames = ["Swift", "Sun", "True", "Bold", "Moon", "Sword",
+            "Wise", "Storm", "Rune", "Brave"];
+
+    /**
+     * Weapons table for Weaponskill discipline in Kai books (IT DOES NOT CONTAIN BOW!!!)
+     */
+    public static readonly lastNames = ["Blade", "Fire", "Hawk", "Heart", "Friend", "Star",
+        "Dancer", "Helm", "Strider", "Shield"];
+
+    /**
+     * Choose player skills UI
+     */
+    public static setKaiName() {
+        // If the name is already set or not a New Order book, do nothing
+        if (state.book.getBookSeries().id != BookSeriesId.NewOrder || state.actionChart.kaiName !== "") {
+            return;
+        }
+
+        // Add HTML to do the choose
+        gameView.appendToSection(mechanicsEngine.getMechanicsUI("mechanics-setKaiName"));
+
+        // Disable next link
+        gameView.enableNextLink(false);
+
+        // Kai Name
+        if (state.actionChart.kaiName !== "") {
+            $("#mechanics-detFirstName").hide();
+            $("#mechanics-detLastName").hide();
+        } else {
+            const $f = $("#mechanics-chooseFirstName");
+            randomMechanics.bindTableRandomLink($f, (value) => {
+                if (state.actionChart.kaiName !== "") {
+                    state.actionChart.kaiName = this.firstNames[value] + " " + state.actionChart.kaiName;
+                }
+                else {
+                    state.actionChart.kaiName = this.firstNames[value];
+                }
+                $f.parent().append("<b>" + translations.text("firstNameSet", [this.firstNames[value]]) + ".</b>");
+                template.updateKaiName();
+                if (state.actionChart.kaiName.includes(" ")) {
+                    gameView.enableNextLink(true);
+                }
+            }, false);
+
+            const $l = $("#mechanics-chooseLastName");
+            randomMechanics.bindTableRandomLink($l, (value) => {
+                if (state.actionChart.kaiName !== "") {
+                    state.actionChart.kaiName = state.actionChart.kaiName + " " + this.lastNames[value];
+                }
+                else {
+                    state.actionChart.kaiName = this.lastNames[value];
+                }
+                $l.parent().append("<b>" + translations.text("lastNameSet", [this.lastNames[value]]) + ".</b>");
+                template.updateKaiName();
+                if (state.actionChart.kaiName.includes(" ")) {
+                    gameView.enableNextLink(true);
+                }
+            }, false);
+        }
+    }
+}

--- a/src/ts/controller/mechanics/mealMechanics.ts
+++ b/src/ts/controller/mechanics/mealMechanics.ts
@@ -1,4 +1,4 @@
-import { state, mechanicsEngine, gameView, KaiDiscipline, MgnDiscipline, GndDiscipline, actionChartController, translations, template } from "../..";
+import { state, mechanicsEngine, gameView, KaiDiscipline, MgnDiscipline, GndDiscipline, actionChartController, translations, template, NewOrderDiscipline, BookSeries, BookSeriesId } from "../..";
 
 /**
  * Meal mechanics
@@ -47,10 +47,12 @@ export class MealMechanics {
         // Check if hunting disciplines, of any book serie, is available
         const huntDisabled = mechanicsEngine.getBooleanProperty($rule, "huntDisabled", false);
 
-        const hasHuntingDiscipline = state.actionChart.hasKaiDiscipline(KaiDiscipline.Hunting) ||
-            state.actionChart.hasMgnDiscipline(MgnDiscipline.Huntmastery) ||
-            state.actionChart.hasGndDiscipline(GndDiscipline.GrandHuntmastery);
-
+        const hasHuntingDiscipline = 
+            state.book.getBookSeries().id === BookSeriesId.NewOrder ? state.actionChart.hasNewOrderDiscipline(NewOrderDiscipline.GrandHuntmastery) :
+            (state.actionChart.hasKaiDiscipline(KaiDiscipline.Hunting) ||
+                state.actionChart.hasMgnDiscipline(MgnDiscipline.Huntmastery) ||
+                state.actionChart.hasGndDiscipline(GndDiscipline.GrandHuntmastery))
+        
         if ( !hasHuntingDiscipline || !state.sectionStates.huntEnabled || huntDisabled ) {
             $(mealSelector + " .mechanics-eatHunt").hide();
         }

--- a/src/ts/controller/mechanics/mechanicsEngine.ts
+++ b/src/ts/controller/mechanics/mechanicsEngine.ts
@@ -1515,6 +1515,19 @@ export const mechanicsEngine = {
     },
 
     /**
+     * New Order: Reset counter of Curing EP restored in the current book
+     */
+    resetNewOrderCuringEPRestoredUse(rule: Element) {
+        if ( state.sectionStates.ruleHasBeenExecuted(rule) ) {
+            // Execute only once
+            return;
+        }
+
+        state.actionChart.resetNewOrderCuringEPRestoredUsed();
+        state.sectionStates.markRuleAsExecuted(rule);
+    },
+
+    /**
      * Set of rules that should be executed only once
      */
     executeOnce(rule: Element) {
@@ -1857,9 +1870,13 @@ export const mechanicsEngine = {
             // Already executed
             return;
         }
+        if (state.book.getBookSeries().id === BookSeriesId.NewOrder && actionChartController.getNewOrderCuringEPRestored() >= 10) {
+            return;
+        }
         sectionState.healingExecuted = true;
         if (state.actionChart.currentEndurance < state.actionChart.getMaxEndurance()) {
             actionChartController.increaseEndurance(+1, true);
+            actionChartController.increaseNewOrderCuringEPRestored(+1);
         }
     },
 

--- a/src/ts/controller/mechanics/mechanicsEngine.ts
+++ b/src/ts/controller/mechanics/mechanicsEngine.ts
@@ -834,6 +834,8 @@ export const mechanicsEngine = {
 
         // Sell a specific item
         const objectId = $rule.attr("objectId");
+        const cls = $rule.attr("class");
+
         if (objectId) {
             const item = state.mechanics.getObject(objectId);
             sectionState.sellPrices.push({
@@ -846,17 +848,22 @@ export const mechanicsEngine = {
                 dessiStoneBonus: false
             });
         }
-
         // Other things (money / meals / special items ...)
-        const cls = $rule.attr("class");
-        if (cls) {
+        else if (cls) {
             let objectIds: string[] = [];
             let except: string[] = mechanicsEngine.getArrayProperty($rule, "except");
 
             if (cls === Item.SPECIAL) {
                 objectIds = state.actionChart.getSpecialItemsIds();
                 except.push(Item.MAP); // don't sell this, come on!
-            } else {
+            }
+            else if (cls == Item.WEAPON) {
+                objectIds = state.actionChart.getWeaponsIds();
+            }
+            else if (cls == Item.OBJECT) {
+                objectIds = state.actionChart.getBackpackItemsIds();
+            }
+            else {
                 mechanicsEngine.debugWarning("Sell rule with invalid class");
             }
 

--- a/src/ts/controller/mechanics/mechanicsEngine.ts
+++ b/src/ts/controller/mechanics/mechanicsEngine.ts
@@ -1857,6 +1857,9 @@ export const mechanicsEngine = {
             // Only if having healing discipline or loyalty bonus
             return;
         }
+        if (state.book.getBookSeries().id === BookSeriesId.NewOrder && actionChartController.getNewOrderCuringEPRestored() >= 10) {
+            return;
+        }
         if (!state.sectionStates.currentSection.startsWith("sect")) {
             // Execute healing only in story sections
             return;
@@ -1870,9 +1873,7 @@ export const mechanicsEngine = {
             // Already executed
             return;
         }
-        if (state.book.getBookSeries().id === BookSeriesId.NewOrder && actionChartController.getNewOrderCuringEPRestored() >= 10) {
-            return;
-        }
+
         sectionState.healingExecuted = true;
         if (state.actionChart.currentEndurance < state.actionChart.getMaxEndurance()) {
             actionChartController.increaseEndurance(+1, true);

--- a/src/ts/controller/mechanics/mechanicsEngine.ts
+++ b/src/ts/controller/mechanics/mechanicsEngine.ts
@@ -497,7 +497,7 @@ export const mechanicsEngine = {
     },
 
     /**
-     * Assing an action to a random table link.
+     * Assign an action to a random table link.
      */
     randomTable(rule: Element) {
         // console.log( 'randomTable rule' );
@@ -753,7 +753,6 @@ export const mechanicsEngine = {
      * There is an available object on the section
      */
     object(rule: Element) {
-
         const sectionState = state.sectionStates.getSectionState();
 
         // Do not execute the rule twice:
@@ -1704,7 +1703,6 @@ export const mechanicsEngine = {
      * a empty objects table will be rendered. If it's empty, no table will be rendered
      */
     showAvailableObjects(renderEmptyTable = false) {
-
         const sectionState = state.sectionStates.getSectionState();
         const thereAreObjects = (sectionState.objects.length >= 1);
 

--- a/src/ts/controller/mechanics/mechanicsEngine.ts
+++ b/src/ts/controller/mechanics/mechanicsEngine.ts
@@ -1,5 +1,5 @@
 import { views, translations, Section, gameView, state, CombatMechanics, randomMechanics, Combat, Item, routing, gameController,
-    App, ExpressionEvaluator, numberPickerMechanics, SkillsSetup, SetupDisciplines, EquipmentSectionMechanics, actionChartController,
+    App, ExpressionEvaluator, numberPickerMechanics, SkillsSetup, KaiNameSetup, SetupDisciplines, EquipmentSectionMechanics, actionChartController,
     Currency, LoreCircle, BookSeriesId, MealMechanics, ActionChartItem, InventoryState, actionChartView, template, Book,
     GrandMasterUpgrade, kaimonasteryController, book2sect238, book2sect308, book3sect88, book6sect26, book6sect284,
     book6sect340, book9sect91, book19sect304, ObjectsTable, ObjectsTableType, setupController, KaiDiscipline, MgnDiscipline,
@@ -412,6 +412,13 @@ export const mechanicsEngine = {
      */
     setSkills() {
         SkillsSetup.setSkills();
+    },
+
+    /**
+     * Choose player Kai name UI
+     */
+    setKaiName() {
+        KaiNameSetup.setKaiName();
     },
 
     /**

--- a/src/ts/controller/mechanics/randomMechanics.ts
+++ b/src/ts/controller/mechanics/randomMechanics.ts
@@ -12,11 +12,11 @@ export const randomMechanics = {
     lastValue: null as number,
 
     /**
-     * Assing an action to a random table link.
+     * Assign an action to a random table link.
      */
     randomTable(rule) {
 
-        // Do not enable anything if the player is death:
+        // Do not enable anything if the player is dead:
         if (state.actionChart.currentEndurance <= 0) {
             return;
         }

--- a/src/ts/controller/mechanics/setupDisciplines.ts
+++ b/src/ts/controller/mechanics/setupDisciplines.ts
@@ -222,7 +222,12 @@ export class SetupDisciplines {
             const nExpectedWeapons = this.getExpectedNWeaponsWeaponmastery();
             if (App.debugMode !== DebugMode.DEBUG && state.actionChart.getWeaponSkill().length >= nExpectedWeapons) {
                 e.preventDefault();
-                alert(translations.text("onlyNWeapons", [nExpectedWeapons]));
+                if (nExpectedWeapons === 1) {
+                    alert(translations.text("onlyNWeapon", [nExpectedWeapons]));
+                }
+                else {
+                    alert(translations.text("onlyNWeapons", [nExpectedWeapons]));
+                }
                 return;
             }
             state.actionChart.getWeaponSkill().push(weaponId);

--- a/src/ts/controller/mechanics/setupDisciplines.ts
+++ b/src/ts/controller/mechanics/setupDisciplines.ts
@@ -82,7 +82,7 @@ export class SetupDisciplines {
             // Set events when checkboxes are clicked
             .find("input[type=checkbox]")
             .on("click", function(e) {
-                self.onDiscliplineCheckBoxClick(e, $(this));
+                self.onDisciplineCheckBoxClick(e, $(this));
             });
 
         // If we are on a magnakai book, add the weapons checkboxes
@@ -271,7 +271,7 @@ export class SetupDisciplines {
      * @param e The click event
      * @param $checkBox The clicked checkbox (JQuery)
      */
-    private onDiscliplineCheckBoxClick(e: JQuery.TriggeredEvent, $checkBox: JQuery<HTMLElement>) {
+    private onDisciplineCheckBoxClick(e: JQuery.TriggeredEvent, $checkBox: JQuery<HTMLElement>) {
 
         // Limit the number of disciplines. Unlimited on debug mode
         const selected: boolean = $checkBox.prop("checked");

--- a/src/ts/controller/mechanics/setupDisciplines.ts
+++ b/src/ts/controller/mechanics/setupDisciplines.ts
@@ -75,7 +75,7 @@ export class SetupDisciplines {
         // Add checkbox for each discipline:
         // eslint-disable-next-line @typescript-eslint/no-this-alias
         const self = this;
-        $('.subsection[id!="mksumary"]').append(mechanicsEngine.getMechanicsUI("mechanics-setDisciplines"))
+        $('.subsection').not('#mksumary').not('#nodispln').append(mechanicsEngine.getMechanicsUI("mechanics-setDisciplines"))
             .each((index, disciplineSection) => {
                 self.setupDisciplineCheckBox($(disciplineSection));
             })

--- a/src/ts/controller/mechanics/setupDisciplines.ts
+++ b/src/ts/controller/mechanics/setupDisciplines.ts
@@ -44,7 +44,7 @@ export class SetupDisciplines {
 
         // Get info about the last played book
         const previousBookNumber = state.book.bookNumber - 1;
-        if (previousBookNumber >= 1) {
+        if (previousBookNumber >= 1 && state.book.bookNumber !== 21) {
             this.previousActionChart = state.getPreviousBookActionChart(previousBookNumber);
 
             // When a series start, by default, keep Weaponmastery with the same weapons from previous series

--- a/src/ts/controller/newGameController.ts
+++ b/src/ts/controller/newGameController.ts
@@ -13,6 +13,7 @@ export const newGameController = {
         // Get available books
         template.setNavTitle( translations.text("kaiChronicles") , "#mainMenu", true);
         template.showStatistics(false);
+        template.showKaiName(false);
         
         state.manualRandomTable = state.actionChart && state.actionChart.manualRandomTable;
 

--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -28,6 +28,7 @@ export * from "./controller/mechanics/mealMechanics";
 export * from "./controller/mechanics/mechanicsEngine";
 export * from "./controller/mechanics/setupDisciplines";
 export * from "./controller/mechanics/skillsSetup";
+export * from "./controller/mechanics/kaiNameSetup";
 export * from "./controller/mechanics/specialSections/book2sect308";
 export * from "./controller/mechanics/specialSections/book3sect88";
 export * from "./controller/mechanics/specialSections/book6sect284";

--- a/src/ts/model/actionChart.ts
+++ b/src/ts/model/actionChart.ts
@@ -119,7 +119,7 @@ export class ActionChart {
     /**
      * New Order limits per section Curing to a total of 20 EP per book
      */
-    private newOrderCuringEPRestored = 0;
+    public newOrderCuringEPRestored = 0;
 
     /**
      * Objects in safekeeping at Kai monastery

--- a/src/ts/model/actionChart.ts
+++ b/src/ts/model/actionChart.ts
@@ -1,4 +1,4 @@
-import { ActionChartItem, SectionItem, App, state, BookSeriesId, GndDiscipline, MgnDiscipline, KaiDiscipline, Item, translations, Combat, BookSeries, mechanicsEngine, LoreCircle, SetupDisciplines, randomTable, Disciplines, DebugMode } from "..";
+import { ActionChartItem, SectionItem, App, state, BookSeriesId, GndDiscipline, MgnDiscipline, KaiDiscipline, Item, translations, Combat, BookSeries, mechanicsEngine, LoreCircle, SetupDisciplines, randomTable, Disciplines, DebugMode, NewOrderDiscipline } from "..";
 
 /**
  * Bonus for CS/EP definition
@@ -117,6 +117,11 @@ export class ActionChart {
      * Objects in safekeeping at Kai monastery
      */
     public kaiMonasterySafekeeping: SectionItem[] = [];
+
+    /**
+     * New Order Kai Name
+     */
+    public kaiName: string = "";
 
     /**
      * List of tags
@@ -1243,6 +1248,11 @@ export class ActionChart {
         return this.hasDiscipline(disciplineId, BookSeriesId.GrandMaster);
     }
 
+    /** Player has a given New Order discipline */
+    public hasNewOrderDiscipline(disciplineId: NewOrderDiscipline): boolean {
+        return this.hasDiscipline(disciplineId, BookSeriesId.NewOrder);
+    }
+
     private getRealDisciplines(seriesId: BookSeriesId): SeriesDisciplines {
         switch (seriesId) {
             case BookSeriesId.Kai:
@@ -1250,6 +1260,7 @@ export class ActionChart {
             case BookSeriesId.Magnakai:
                 return this.magnakaiDisciplines;
             case BookSeriesId.GrandMaster:
+            case BookSeriesId.NewOrder:
                 return this.grandMasterDisciplines;
             default:
                 mechanicsEngine.debugWarning("ActionChart.getSeriesDisciplines: Wrong book series");
@@ -1369,6 +1380,9 @@ export class ActionChart {
                     o.magnakaiDisciplines = { disciplines: o.disciplines, weaponSkill: o.weaponSkill };
                     break;
                 case BookSeriesId.GrandMaster:
+                    o.grandMasterDisciplines = { disciplines: o.disciplines, weaponSkill: o.weaponSkill };
+                    break;
+                case BookSeriesId.NewOrder:
                     o.grandMasterDisciplines = { disciplines: o.disciplines, weaponSkill: o.weaponSkill };
                     break;
             }

--- a/src/ts/model/actionChart.ts
+++ b/src/ts/model/actionChart.ts
@@ -588,7 +588,7 @@ export class ActionChart {
     public getMaxEndurance(): number {
 
         if (this.endurance <= 0) {
-            // If the original endurance is zero, the player is death
+            // If the original endurance is zero, the player is dead
             return 0;
         }
 
@@ -898,7 +898,7 @@ export class ActionChart {
                     bonuses.push({
                         concept: o.name,
                         increment: o.combatSkillEffect
-                    });
+                            });
                 }
             });
         }

--- a/src/ts/model/actionChart.ts
+++ b/src/ts/model/actionChart.ts
@@ -775,6 +775,12 @@ export class ActionChart {
                 });
             }
 
+        } else if (this.isWeaponskillActive(bowCombat, BookSeriesId.NewOrder)) {
+            // Grand Master / Grand Weaponmastery bonuses
+            bonuses.push({
+                concept: translations.text("grdweaponmastery"),
+                increment: 5
+            });
         } else if (this.isWeaponskillActive(bowCombat, BookSeriesId.GrandMaster)) {
             // Grand Master / Grand Weaponmastery bonuses
             // Exception: Book 13. It seems an errata, but it says EVERYWHERE it's +3 for bow bonus:
@@ -783,8 +789,8 @@ export class ActionChart {
                 concept: translations.text("grdweaponmastery"),
                 increment: inc
             });
-
-        } else if (this.isWeaponskillActive(bowCombat, BookSeriesId.Magnakai)) {
+        } else if (this.isWeaponskillActive(bowCombat, BookSeriesId.Magnakai) 
+            && state.book.getBookSeries().id !== BookSeriesId.NewOrder) {
             // Magnakai / Weaponmastery bonuses
 
             let bonus = +3;
@@ -830,7 +836,8 @@ export class ActionChart {
                     weapons, whether fired (e.g. a bow) or thrown (e.g. a dagger). When using a bow or thrown weapon and instructed to pick a
                     number from the Random Number Table, add 2 to the number picked if you are a Mentora with the Magnakai Discipline
                     of Weaponmastery */
-                if (this.hasMgnDiscipline(MgnDiscipline.Weaponmastery) && this.getDisciplines(BookSeriesId.Magnakai).length >= 7) {
+                if (state.book.getBookSeries().id !== BookSeriesId.NewOrder
+                && this.hasMgnDiscipline(MgnDiscipline.Weaponmastery) && this.getDisciplines(BookSeriesId.Magnakai).length >= 7) {
                     bonuses.push({
                         concept: translations.text("mentora"),
                         increment: +2

--- a/src/ts/model/book.ts
+++ b/src/ts/model/book.ts
@@ -299,7 +299,7 @@ export class Book {
             // Parse the disciplines section
             // eslint-disable-next-line @typescript-eslint/no-this-alias
             const self = this;
-            $(this.bookXml).find('section[id=discplnz] > data > section[id!="mksumary"]')
+            $(this.bookXml).find('section[id=discplnz] > data section').not('#mksumary').not('#nodispln')
             .each( function(disciplineSection) {
 
                 const $node = $(this);

--- a/src/ts/model/bookSeries.ts
+++ b/src/ts/model/bookSeries.ts
@@ -7,7 +7,8 @@ export enum BookSeriesId {
     // Order is important!
     Kai = 0,
     Magnakai = 1,
-    GrandMaster = 2
+    GrandMaster = 2,
+    NewOrder = 3
 }
 
 // TODO: Add other common disciplines definitions to BookSeries and use them from here (healing, hunt, etc)
@@ -50,7 +51,8 @@ export class BookSeries {
     public static readonly series: BookSeries[] = [
         new BookSeries(BookSeriesId.Kai, 1, 5, 5, KaiDiscipline.Weaponskill, 1, KaiDiscipline.Mindshield, 10, 20),
         new BookSeries(BookSeriesId.Magnakai, 6, 12, 3, MgnDiscipline.Weaponmastery, 3, MgnDiscipline.PsiScreen, 10, 20),
-        new BookSeries(BookSeriesId.GrandMaster, 13, 20, 4, GndDiscipline.GrandWeaponmastery, 2, GndDiscipline.KaiScreen, 25, 30)
+        new BookSeries(BookSeriesId.GrandMaster, 13, 20, 4, GndDiscipline.GrandWeaponmastery, 2, GndDiscipline.KaiScreen, 25, 30),
+        new BookSeries(BookSeriesId.NewOrder, 21, 21, 5, GndDiscipline.GrandWeaponmastery, 1, GndDiscipline.KaiScreen, 25, 30)
     ];
 
     private constructor(id: BookSeriesId, bookStart: number, bookEnd: number, initialNDisciplines: number,

--- a/src/ts/model/bookValidator.ts
+++ b/src/ts/model/bookValidator.ts
@@ -400,10 +400,10 @@ export class BookValidator {
         const classFound = $rule.attr("class");
         const onlyOne = ( ( objectIdFound && !classFound ) || ( !objectIdFound && classFound ) );
         if ( !onlyOne ) {
-            this.addError( $rule , 'Must to have a "objectId" or "class" attribute, and only one' );
+            this.addError( $rule , 'Must have a "objectId" or "class" attribute, and only one' );
         }
         if ( classFound && !$rule.attr("count") ) {
-            this.addError( $rule , 'Must to have a "count" attribute' );
+            this.addError( $rule , 'Must have a "count" attribute' );
         }
         this.validateNumericExpression( $rule , "count" );
     }
@@ -519,9 +519,10 @@ export class BookValidator {
 
         this.checkThereAreCombats( $rule );
 
+        const combats = this.currentSection.getCombats();
         const combatIndex = parseInt( $rule.attr("index"), 10 );
         if ( combatIndex ) {
-            const nCombats = this.currentSection.getCombats().length;
+            const nCombats = combats.length;
             if ( nCombats <= combatIndex ) {
                 this.addError( $rule , "There is no combat with index " + combatIndex );
             }
@@ -541,6 +542,12 @@ export class BookValidator {
 
         if ($rule.attr("noKaiBlast") === "true" && ( $rule.attr("noMindblast") !== "true" || $rule.attr("noPsiSurge") !== "true" ) ) {
             this.addError($rule, "If noKaiBlast attr. is true, noMindblast, and noPsiSurge attributes should be true too");
+        }
+
+        for (const c of combats) {
+            if (this.book.bookNumber >= 21 && c.properties) {
+                this.addError($rule, "Combats in New Order should have at least day or night property")
+            }
         }
 
         // TODO: Check attr "noWeapon" is boolean or number

--- a/src/ts/model/bookValidator.ts
+++ b/src/ts/model/bookValidator.ts
@@ -544,12 +544,6 @@ export class BookValidator {
             this.addError($rule, "If noKaiBlast attr. is true, noMindblast, and noPsiSurge attributes should be true too");
         }
 
-        for (const c of combats) {
-            if (this.book.bookNumber >= 21 && c.properties) {
-                this.addError($rule, "Combats in New Order should have at least day or night property")
-            }
-        }
-
         // TODO: Check attr "noWeapon" is boolean or number
     }
 

--- a/src/ts/model/bookValidator.ts
+++ b/src/ts/model/bookValidator.ts
@@ -276,7 +276,7 @@ export class BookValidator {
         try {
             for ( const keyword of ExpressionEvaluator.getKeywords( expression ) ) {
                 if ( !ExpressionEvaluator.isValidKeyword( keyword ) ) {
-                    this.addError( $rule , "Unkwown keyword " + keyword );
+                    this.addError( $rule , "Unknown keyword " + keyword );
                 }
                 expression = expression.replaceAll( keyword , "0" );
             }
@@ -634,7 +634,7 @@ export class BookValidator {
         }
 
         const cls = $rule.attr("class");
-        if ( cls && cls !== "special" ) {
+        if ( cls && cls !== "special" && cls !== "weapon" && cls !== "object") {
             this.addError( $rule , 'Wrong "class" property value' );
         }
 
@@ -644,8 +644,8 @@ export class BookValidator {
         this.validateObjectIdsAttribute( $rule , "except" , true , false );
 
         // "objectId" or "class" are mandatory, and exclusive
-        if ( ( !objectId && !cls ) || ( objectId && cls ) ) {
-            this.addError( $rule , 'One and only one of "objectId" and "class" are mandatory' );
+        if ( ( !objectId && !cls )) {
+            this.addError( $rule , 'One of "objectId" and "class" are mandatory' );
         }
     }
 

--- a/src/ts/model/bookValidator.ts
+++ b/src/ts/model/bookValidator.ts
@@ -539,8 +539,8 @@ export class BookValidator {
             this.addError($rule, "If noKaiSurge attr. is true, noMindblast and noPsiSurge attributes should be true too");
         }
 
-        if ($rule.attr("noKaiBlast") === "true" && ( $rule.attr("noMindblast") !== "true" || $rule.attr("noPsiSurge") !== "true" || $rule.attr("noKaiSurge") !== "true" ) ) {
-            this.addError($rule, "If noKaiBlast attr. is true, noMindblast, noPsiSurge and noKaiSurge attributes should be true too");
+        if ($rule.attr("noKaiBlast") === "true" && ( $rule.attr("noMindblast") !== "true" || $rule.attr("noPsiSurge") !== "true" ) ) {
+            this.addError($rule, "If noKaiBlast attr. is true, noMindblast, and noPsiSurge attributes should be true too");
         }
 
         // TODO: Check attr "noWeapon" is boolean or number

--- a/src/ts/model/disciplines.ts
+++ b/src/ts/model/disciplines.ts
@@ -1,4 +1,4 @@
-import { BookSeriesId, KaiDiscipline, MgnDiscipline, GndDiscipline } from "..";
+import { BookSeriesId, KaiDiscipline, MgnDiscipline, GndDiscipline, NewOrderDiscipline } from "..";
 
 /**
  * Disciplines helpers
@@ -22,6 +22,8 @@ export class Disciplines {
                 return Disciplines.getDisciplinesIds(MgnDiscipline);
             case BookSeriesId.GrandMaster:
                 return Disciplines.getDisciplinesIds(GndDiscipline);
+            case BookSeriesId.NewOrder:
+                return Disciplines.getDisciplinesIds(NewOrderDiscipline);
             default:
                 return [];
         }

--- a/src/ts/model/disciplinesDefinitions.ts
+++ b/src/ts/model/disciplinesDefinitions.ts
@@ -42,3 +42,23 @@ export enum GndDiscipline {
     MagiMagic = "magi",
     KaiAlchemy = "alchemy"
 }
+
+/** New Order series disciplines codes */
+export enum NewOrderDiscipline {
+    GrandWeaponmastery = "wpnmstry", // Duplicate!
+    AnimalMastery = "anmlmstr", // Duplicate!
+    Deliverance = "deliver", // Duplicate!
+    Assimilance = "assimila", // Duplicate!
+    GrandHuntmastery = "hntmstry", // Duplicate!
+    GrandPathsmanship = "pthmnshp", // Duplicate!
+    KaiSurge = "kaisurge", // Duplicate!
+    KaiScreen = "kaiscrn", // Duplicate!
+    GrandNexus = "nexus", // Duplicate!
+    Telegnosis = "gnosis", // Duplicate!
+    MagiMagic = "magi", // Duplicate!
+    KaiAlchemy = "alchemy", // Duplicate!
+    Astrology = "astrolgy",
+    Herbmastery = "herbmst",
+    Elementalism = "element",
+    Bardsmanship = "bardsman"
+}

--- a/src/ts/model/expressionEvaluator.ts
+++ b/src/ts/model/expressionEvaluator.ts
@@ -46,6 +46,12 @@ export class ExpressionEvaluator {
             return sectionState.getCntSectionObjects("object");
         },
 
+        // Meal items on section
+        "[MEALS-CNT-ON-SECTION]"() {
+            const sectionState = state.sectionStates.getSectionState();
+            return sectionState.getSectionObjects("object").filter((item) => item.id === "meal").length;
+        },
+
         // Backpack items on section (includes meals)
         "[BACKPACK-ITEMS-CNT-ON-ACTIONCHART]"() {
             return state.actionChart.getNBackpackItems();

--- a/src/ts/model/inventoryState.ts
+++ b/src/ts/model/inventoryState.ts
@@ -26,7 +26,6 @@ export class InventoryState {
      * 'allobjects' = weapons, special items and backpack items
      */
     public static fromActionChart(objectTypes: string, actionChart: ActionChart): InventoryState {
-
         const objects = new InventoryState();
 
         if (objectTypes === "all" || objectTypes === "allobjects") {
@@ -43,6 +42,13 @@ export class InventoryState {
         } else if (objectTypes === "weaponlike") {
             for (const w of actionChart.getWeaponAChartItems(false)) {
                 objects.addItem(w.clone());
+            }
+        //Following rule currently only used in New Order Book 1, so there is no Special Item bow (yet) type 
+        } else if (objectTypes === "bow") { 
+            for (const w of actionChart.getWeaponAChartItems(false)) {
+                if (w.getItem().isWeaponType(Item.BOW)) {
+                    objects.addItem(w.clone());
+                }
             }
         } else {
             const msg = "Wrong objectTypes: " + objectTypes;

--- a/src/ts/model/item.ts
+++ b/src/ts/model/item.ts
@@ -1,3 +1,4 @@
+import { INTERNAL_COMPUTE_OFFSET_SCRIPT } from "selenium-webdriver/lib/input";
 import { Book, translations, mechanicsEngine, Section, state } from "..";
 
 /**

--- a/src/ts/model/loreCircle.ts
+++ b/src/ts/model/loreCircle.ts
@@ -99,6 +99,7 @@ export class LoreCircle {
     public static getCirclesBonuses( disciplines: string[] , type: string ): Bonus[] {
         const bonuses: Bonus[] = [];
         
+        // No Lore Circle bonuses in New Order
         if (state.book.getBookSeries().id !== BookSeriesId.NewOrder) {
             const circles = LoreCircle.getCircles( disciplines );
             for ( const c of circles ) {

--- a/src/ts/model/loreCircle.ts
+++ b/src/ts/model/loreCircle.ts
@@ -1,4 +1,4 @@
-import { MgnDiscipline, translations, Bonus } from "..";
+import { MgnDiscipline, translations, Bonus, state, BookSeries, BookSeriesId } from "..";
 
 /**
  * Lore-circles for Magnakai disciplines
@@ -97,16 +97,18 @@ export class LoreCircle {
      * @param type Type of bonuses to return: 'EP' for endurance points. 'CS' for combat skill
      */
     public static getCirclesBonuses( disciplines: string[] , type: string ): Bonus[] {
-
-        const circles = LoreCircle.getCircles( disciplines );
         const bonuses: Bonus[] = [];
-        for ( const c of circles ) {
-            const bonusValue = ( type === "CS" ? c.bonusCS : c.bonusEP );
-            if ( bonusValue > 0 ) {
-                bonuses.push({
-                    concept: c.getDescription(),
-                    increment: bonusValue
-                });
+        
+        if (state.book.getBookSeries().id !== BookSeriesId.NewOrder) {
+            const circles = LoreCircle.getCircles( disciplines );
+            for ( const c of circles ) {
+                const bonusValue = ( type === "CS" ? c.bonusCS : c.bonusEP );
+                if ( bonusValue > 0 ) {
+                    bonuses.push({
+                        concept: c.getDescription(),
+                        increment: bonusValue
+                    });
+                }
             }
         }
         return bonuses;

--- a/src/ts/model/projectAon.ts
+++ b/src/ts/model/projectAon.ts
@@ -188,6 +188,14 @@ export const projectAon = {
             biographies: [ "jdbiolw" , "bwbiolw" ]
         },
 
+        /////////// NEW ORDER ///////////
+        // Book 21:
+        {
+            title: "Voyage of the Moonstone",
+            code: "21votm",
+            illustrators: [ "newton", "williams" ],
+            biographies: [ "jdbiolw" , "bwbiolw" ]
+        },
     ] as BookMetadata[],
 
     /**

--- a/src/ts/model/sectionRenderer.ts
+++ b/src/ts/model/sectionRenderer.ts
@@ -566,7 +566,6 @@ export class SectionRenderer {
     }
     private tr($node: JQuery<HTMLElement>, level: number): string { return this.renderHtmlNode( $node , level ); }
     private th($node: JQuery<HTMLElement>, level: number): string {
-         //return this.renderHtmlNode( $node , level ); 
          if ($node.attr("colspan") !== undefined) {
             return '<th colspan=' + $node.attr("colspan") + '>' + this.renderNodeChildren( $node , level ) + "</th>";
          }
@@ -574,5 +573,12 @@ export class SectionRenderer {
             return this.renderHtmlNode( $node , level );
          }
     }
-    private td($node: JQuery<HTMLElement>, level: number): string { return this.renderHtmlNode( $node , level ); }
+    private td($node: JQuery<HTMLElement>, level: number): string { 
+        if ($node.attr("colspan") !== undefined) {
+            return '<td colspan=' + $node.attr("colspan") + '>' + this.renderNodeChildren( $node , level ) + "</td>";
+         }
+         else {
+            return this.renderHtmlNode( $node , level );
+         }
+    }
 }

--- a/src/ts/model/sectionRenderer.ts
+++ b/src/ts/model/sectionRenderer.ts
@@ -15,7 +15,7 @@ export class SectionRenderer {
      * Only illustrations of following authors are rendered (Others are not included on PAON).
      * This covers up to book 9. There are illustrations of authors that are not distributed (ex. JC Alvarez)
      */
-    private static toRenderIllAuthors = [ "Gary Chalk" , "Brian Williams" ];
+    private static toRenderIllAuthors = [ "Gary Chalk" , "Brian Williams", "Trevor Newton" ];
 
     /** The section to render */
     public sectionToRender: Section;
@@ -116,7 +116,7 @@ export class SectionRenderer {
 
             // Call the function renderer (this class method with the tag name)
             if ( !this[tagName] ) {
-                const msg = this.sectionToRender.sectionId + ": Unkown tag: " + tagName;
+                const msg = this.sectionToRender.sectionId + ": Unknown tag: " + tagName;
                 mechanicsEngine.debugWarning(msg);
                 throw msg;
             } else {
@@ -565,6 +565,14 @@ export class SectionRenderer {
         return '<table class="table table-striped">' + this.renderNodeChildren( $node , level ) + "</table>";
     }
     private tr($node: JQuery<HTMLElement>, level: number): string { return this.renderHtmlNode( $node , level ); }
-    private th($node: JQuery<HTMLElement>, level: number): string { return this.renderHtmlNode( $node , level ); }
+    private th($node: JQuery<HTMLElement>, level: number): string {
+         //return this.renderHtmlNode( $node , level ); 
+         if ($node.attr("colspan") !== undefined) {
+            return '<th colspan=' + $node.attr("colspan") + '>' + this.renderNodeChildren( $node , level ) + "</th>";
+         }
+         else {
+            return this.renderHtmlNode( $node , level );
+         }
+    }
     private td($node: JQuery<HTMLElement>, level: number): string { return this.renderHtmlNode( $node , level ); }
 }

--- a/src/ts/scripts/bookData.ts
+++ b/src/ts/scripts/bookData.ts
@@ -93,7 +93,9 @@ export class BookData {
 
         const sourceDir = this.getSvnIllustrationsDir(author);
         const targetDir = this.getBookDir() + "/ill";
-        fs.mkdirSync( targetDir );
+        if (!fs.existsSync(targetDir)) {
+            fs.mkdirSync(targetDir);
+        }
         fs.copySync(sourceDir, targetDir);
 
         if ( this.bookNumber === 9) {

--- a/src/ts/state.ts
+++ b/src/ts/state.ts
@@ -263,10 +263,16 @@ export class State {
         this.sectionStates = new BookSectionStates();
         this.actionChartSect1 = null;
 
-        // Restore Kai monastery objects
-        this.restoreKaiMonasterySectionObjects();
+        if (this.book.bookNumber !== 21) {
+            // Restore Kai monastery objects
+            this.restoreKaiMonasterySectionObjects();
 
-        this.persistState();
+            this.persistState();
+        }
+        // Start a new character for the New Order series
+        else {
+            this.setup(this.book.bookNumber, false);
+        }
     }
 
     /**

--- a/src/ts/template.ts
+++ b/src/ts/template.ts
@@ -79,6 +79,17 @@ export const template = {
     },
 
     /**
+     * Show / hide Kai Name on navigation bar
+     */
+    showKaiName(show: boolean) {
+        if ( show ) {
+            template.updateKaiName();
+        } else {
+            $("#template-kaiNameHeader").hide();
+        }
+    },
+
+    /**
      * Update player statistics
      */
     updateStatistics(doNotAnimate: boolean = false) {
@@ -101,6 +112,20 @@ export const template = {
             } else {
                 $("#template-map").hide();
             }
+        }
+    },
+
+    /**
+     * Update Kai Name
+     */
+    updateKaiName(doNotAnimate: boolean = false) {
+        // Update Kai name
+        if ( !state.actionChart ||
+            ( state.actionChart.kaiName === "" ) ) {
+            $("#template-kaiNameHeader").hide();
+        } else {
+            $("#template-kaiNameHeader").show();
+            $("#template-kaiName").text( state.actionChart.kaiName );
         }
     },
 

--- a/src/ts/template.ts
+++ b/src/ts/template.ts
@@ -85,7 +85,7 @@ export const template = {
         if ( show ) {
             template.updateKaiName();
         } else {
-            $("#template-kaiNameHeader").hide();
+            $("#template-kaiName").hide();
         }
     },
 
@@ -122,9 +122,9 @@ export const template = {
         // Update Kai name
         if ( !state.actionChart ||
             ( state.actionChart.kaiName === "" ) ) {
-            $("#template-kaiNameHeader").hide();
+            $("#template-kaiName").hide();
         } else {
-            $("#template-kaiNameHeader").show();
+            $("#template-kaiName").show();
             $("#template-kaiName").text( state.actionChart.kaiName );
         }
     },

--- a/src/ts/views/actionChartView.ts
+++ b/src/ts/views/actionChartView.ts
@@ -28,6 +28,9 @@ export const actionChartView = {
         // Fill the chart objects lists
         actionChartView.updateObjectsLists();
 
+        // Full the Kai Weapon area
+        actionChartView.fillKaiWeapon(actionChart);
+
         // Bind event for drop meals
         ObjectsTable.bindTableEquipmentEvents( $("#achart-dropmeal") , ObjectsTableType.INVENTORY );
 
@@ -105,7 +108,8 @@ export const actionChartView = {
             .text( state.book.getKaiTitle( actionChart.getDisciplines().length ) );
 
         // Lore circles:
-        if (state.book.getBookSeries().id === BookSeriesId.Magnakai || state.actionChart.getDisciplines(BookSeriesId.Magnakai).length > 0) {
+        if (state.book.getBookSeries().id !== BookSeriesId.NewOrder 
+        && (state.book.getBookSeries().id === BookSeriesId.Magnakai || state.actionChart.getDisciplines(BookSeriesId.Magnakai).length > 0)) {
             // Only for Magnakai books, or if player has played some Magnakai books
             const circles = actionChart.getLoreCircles();
             if ( circles.length === 0 ) {
@@ -164,6 +168,29 @@ export const actionChartView = {
             $displines.find("button").on("click", function(e) {
                 $(this).parent().find("i").toggle();
             });
+        }
+    },
+
+    /**
+     * Render the Kai Weapon table
+     * @param {ActionChart} actionChart The action chart
+     */
+    fillKaiWeapon(actionChart: ActionChart) {
+        if (state.book.getBookSeries().id === BookSeriesId.NewOrder) {
+            const kaiWeapon = actionChart.getKaiWeapon();
+            if (kaiWeapon) {
+                var item = state.mechanics.getObject(kaiWeapon);
+                $("#kaiWeaponName").text(item.name.charAt(0).toUpperCase() + item.name.slice(1));
+                $("#kaiWeaponProperties").text(item.description);
+                $("#kaiWeaponType").text(item.weaponType.charAt(0).toUpperCase() + item.weaponType.slice(1));
+                $("#kaiWeaponBonus").text("+" + item.combatSkillEffect + "CS");
+            }
+            else {
+                $("#kaiWeaponName").text("");
+                $("#kaiWeaponProperties").text("");
+                $("#kaiWeaponType").text("");
+                $("#kaiWeaponBonus").text("");
+            }
         }
     },
 

--- a/src/ts/views/actionChartView.ts
+++ b/src/ts/views/actionChartView.ts
@@ -121,6 +121,10 @@ export const actionChartView = {
             $("#achart-circles").hide();
         }
 
+        if (state.book.getBookSeries().id !== BookSeriesId.NewOrder) {
+            $("#kaiWeapon").hide();
+        }
+
         // TODO: Display the discipline "quote" tag instead the name
         const $displines = $("#achart-disciplines > tbody");
         if ( actionChart.getDisciplines().length === 0 ) {

--- a/src/ts/views/viewsUtils/translations.ts
+++ b/src/ts/views/viewsUtils/translations.ts
@@ -110,6 +110,7 @@ export class Translations {
         "combatSkillSet" : "Your Combat Skill is {0}",
         "enduranceSet" : "Your Endurance Points are {0}",
         "maxDisciplines" : "You can choose only {0} disciplines",
+        "onlyNWeapon" : "You can select only {0} weapon",
         "onlyNWeapons" : "You can select only {0} weapons",
         "firstNameSet" : "Your first name is {0}",
         "lastNameSet" : "Your last name is {0}",

--- a/src/ts/views/viewsUtils/translations.ts
+++ b/src/ts/views/viewsUtils/translations.ts
@@ -111,6 +111,8 @@ export class Translations {
         "enduranceSet" : "Your Endurance Points are {0}",
         "maxDisciplines" : "You can choose only {0} disciplines",
         "onlyNWeapons" : "You can select only {0} weapons",
+        "firstNameSet" : "Your first name is {0}",
+        "lastNameSet" : "Your last name is {0}",
 
         //////////////////////////////////////
         // Grand Master upgrade

--- a/www/css/kaichronicles.css
+++ b/www/css/kaichronicles.css
@@ -215,8 +215,12 @@ div.signpost {
 }
 
 /* The statistics on header is like a link */
-#template-statistics, #template-kaiNameHeader {
+#template-statistics {
     cursor: pointer;
+}
+
+#template-kaiName {
+    margin-right: 10px;
 }
 
 /* Style to force to hide the toggle menu button */

--- a/www/css/kaichronicles.css
+++ b/www/css/kaichronicles.css
@@ -215,7 +215,7 @@ div.signpost {
 }
 
 /* The statistics on header is like a link */
-#template-statistics {
+#template-statistics, #template-kaiNameHeader {
     cursor: pointer;
 }
 

--- a/www/data/mechanics-20.xml
+++ b/www/data/mechanics-20.xml
@@ -2569,7 +2569,6 @@
 
         <section id="sect350">
             <unregisterGlobalRule id="planeofdarknessb20" />
-            <message text="Congratulation! You have finished the last book of Kai Chronicles!" />
         </section>
     </sections>
 </mechanics>

--- a/www/data/mechanics-21.xml
+++ b/www/data/mechanics-21.xml
@@ -1,0 +1,576 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<mechanics book="20" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/cracrayol/kaichronicles/master/www/data/mechanics.xsd">
+
+    <!-- GAME RULES -->
+    <sections>
+        <section id="tssf">
+            <!-- Restore the endurance to the maximum -->
+            <endurance count="+[MAXENDURANCE]" />
+            <!-- Drop the previous books map -->
+            <drop objectId="map" />
+            <!-- Restore Deliverance use each X days -->
+            <restoreDeliveranceUse />
+        </section>
+
+        <section id="gamerulz">
+            <!-- Select the player skills (weapons skill and endurance) UI -->
+            <setSkills />
+        </section>
+
+        <section id="kainame">
+            <!-- Select the player Kai name UI -->
+            <setKaiName />
+        </section>
+        
+        <section id="discplnz">
+            <!-- Select the Kai disciplines UI -->
+            <setDisciplines />
+        </section>
+
+        <section id="equipmnt" pickMaximum="5">
+            <!-- Do not pick 2 maps! -->
+            <test not="true" hasObject="map">
+                <pick objectId="map" />
+            </test>
+            <test not="true" hasObject="backpack">
+                <pick objectId="backpack" />
+            </test>
+
+            <randomTable>
+                <pick class="money" count="[RANDOM] + 20" excessToKaiMonastry="true" />
+            </randomTable>
+
+            <object objectId="quarterstaff" />
+            <object objectId="bow" />
+            <object objectId="quiver" count="6" />
+            <object objectId="flute" />
+            <object objectId="dagger" />
+            <object objectId="sword" />
+            <object objectId="meal" index="0" />
+            <object objectId="meal" index="1" />
+            <object objectId="rope" />
+            <object objectId="laumspurpotion4" />
+            <object objectId="axe" />
+
+            <chooseEquipment text="Click on the Random Table link to get money before continuing" />
+            <message text="You may take up to five of the following (all meals count as one object):" />
+        </section>
+
+        <section id="sect1">
+            <pick objectId="moonstone" />
+        </section>
+
+        <section id="sect5">
+            <combat noWeapon="true" />
+            <afterCombatTurn turn="1">
+                <combat noWeapon="false" />
+            </afterCombatTurn>
+        </section>
+
+        <section id="sect8">
+            <endurance count="3" />
+        </section>
+
+        <section id="sect9">
+            <endurance count="-1" />
+        </section>
+
+        <section id="sect10">
+            <pick class="arrow" count="-1" />
+        </section>
+
+        <section id="sect12">
+            <endurance count="-2" />
+        </section>
+
+        <section id="sect13">
+            <test not="true" hasDiscipline="magi">
+                <choiceState section="sect303" set="disabled" />
+            </test>
+            <test not="true" hasDiscipline="element">
+                <choiceState section="sect210" set="disabled" />
+            </test>
+        </section>
+
+        <section id="sect14">
+            <choiceState section="sect85" set="disabled" />
+            <test hasDiscipline="alchemy">
+                <choiceState section="sect85" set="enabled" />
+                <choiceState section="sect98" set="disabled" />
+            </test>
+        </section>
+
+        <section id="sect15">
+            <endurance count="-6" />
+        </section>
+
+        <section id="sect16">
+            <death />
+        </section>
+
+        <section id="sect17">
+            <pick class="money" count="-3" />
+        </section>
+
+        <section id="sect18">
+            <death />
+        </section>
+
+        <section id="sect21">
+            <choiceState section="all" set="disabled" />
+            <afterCombatTurn turn="2">
+                <test combatsWon="false">
+                    <choiceState section="sect13" set="enabled" />
+                </test>
+            </afterCombatTurn>
+            <afterCombats>
+                <test combatsWon="true">
+                    <choiceState section="sect13" set="disabled" />
+                    <choiceState section="sect97" set="enabled" />
+                </test>
+            </afterCombats>
+        </section>
+        
+        <section id="sect22">
+            <endurance count="-2" />
+        </section>
+
+        <section id="sect23">
+            <pick class="money" count="10" />
+            <meal />
+        </section>
+
+        <section id="sect24">
+            <test not="true" expression="[MONEY] >= 1">
+                <choiceState section="sect219" set="disabled" />
+            </test>
+        </section>
+
+        <section id="sect26">
+            <endurance count="-8" />
+        </section>
+
+        <section id="sect27">
+            <endurance count="-1" />
+            <choiceState section="sect158" set="disabled" />
+            <test hasDiscipline="alchemy">
+                <choiceState section="sect158" set="enabled" />
+                <choiceState section="sect247" set="disabled" />
+            </test>
+        </section>
+
+        <section id="sect28">
+            <endurance count="3" />
+        </section>
+
+        <section id="sect29">
+            <endurance count="-3" />
+        </section>
+
+        <section id="sect30">
+            <pick class="money" count="1" />
+            <drop backpackItemSlots="1" />
+        </section>
+
+        <section id="sect31">
+            <choiceState section="all" set="disabled" />
+            <afterCombats>
+                <test not="true" expression="[COMBATSDURATION] > 4">
+                    <choiceState section="sect289" set="enabled" />
+                </test>
+                <test expression="[COMBATSDURATION] > 4">
+                    <choiceState section="sect195" set="enabled" />
+                </test>
+            </afterCombats>
+        </section>
+
+        <section id="sect33">
+            <drop objectId="allweapons" />
+        </section>
+
+        <section id="sect34">
+            <!-- TODO: Barter for room -->
+        </section>
+
+        <section id="sect36">
+            <endurance count="-3" />
+        </section>
+
+        <section id="sect37">
+            <choiceState section="sect272" set="disabled" />
+
+            <test hasDiscipline="bardsman">
+                <test hasObject="flute">
+                    <choiceState section="sect272" set="enabled" />
+                    <choiceState section="sect8" set="disabled" />
+                </test>
+            </test>
+        </section>
+
+        <section id="sect40">
+               <!-- TODO: Link to answer -->
+        </section>
+
+        <section id="sect42">
+            <choiceState section="all" set="disabled" />
+            <randomTable>
+                <case from="0" to="4">
+                    <choiceState section="sect67" set="enabled" />
+                </case>
+                <case from="5" to="9">
+                    <choiceState section="sect205" set="enabled" />
+                </case>
+            </randomTable>
+        </section>
+
+        <section id="sect43">
+            <combat noMindblast="true" />
+        </section>
+
+        <section id="sect44">
+            <combat combatSkillModifier="+3" />
+            <afterCombatTurn turn="2">
+                <combat combatSkillModifier="+0" />
+            </afterCombatTurn>
+        </section>
+
+        <section id="sect46">
+            <choiceState section="all" set="disabled" />
+            <randomTable>
+                <case from="0" to="4">
+                    <choiceState section="sect135" set="enabled" />
+                </case>
+                <case from="5" to="9">
+                    <choiceState section="sect4" set="enabled" />
+                </case>
+            </randomTable>
+            <test hasDiscipline="assimila">
+                <randomTableIncrement increment="3" />
+            </test>
+        </section>
+
+        <section id="sect48">
+            <choiceState section="sect199" set="disabled" />
+            <test hasDiscipline="kaiscrn">
+                <choiceState section="sect199" set="enabled" />
+                <choiceState section="sect239" set="disabled" />
+            </test>
+        </section>
+
+        <section id="sect50">
+            <combat noMindblast="true" noKaiSurge="true" noPsiSurge="true" noKaiBlast="true" noKaiRay="true" />
+        </section>
+
+        <section id="sect51">
+            <choiceState section="all" set="disabled" />
+
+            <randomTable>
+                <case from="0" to="1">
+                    <choiceState section="sect342" set="enabled" />
+                </case>
+                <case from="2" to="7">
+                    <choiceState section="sect15" set="enabled" />
+                </case>
+                <case from="8">
+                    <choiceState section="sect203" set="enabled" />
+                </case>
+            </randomTable>
+            <test hasDiscipline="hntmstry">
+                <randomTableIncrement increment="3" />
+                <!-- TODO: Allow player to deduct EP to increase their roll -->
+            </test>
+        </section>
+
+        <section id="sect52">
+            <endurance count="3" />
+        </section>
+
+        <section id="sect53">
+            <choiceState section="sect107" set="disabled" />
+            <test hasDiscipline="alchemy">
+                <choiceState section="sect107" set="enabled" />
+                <choiceState section="sect115" set="disabled" />
+            </test>
+        </section>
+
+        <section id="sect55">
+            <choiceState section="all" set="disabled" />
+
+            <randomTable>
+                <case from="0" to="1">
+                    <choiceState section="sect16" set="enabled" />
+                </case>
+                <case from="2">
+                    <choiceState section="sect294" set="enabled" />
+                </case>
+            </randomTable>
+        </section>
+
+        <section id="sect56">
+            <drop backpackItemSlots="1" />
+        </section>
+
+        <section id="sect57">
+            <endurance count="-5" />
+        </section>
+
+        <section id="sect58">
+            <onInventoryEvent>
+                <test expression="([BACKPACK-ITEMS-CNT-ON-SECTION] - [MEALS-CNT-ON-SECTION]) >= 2">
+                    <choiceState section="sect333" set="enabled" />
+                </test>
+                <test not="true" expression="([BACKPACK-ITEMS-CNT-ON-SECTION] - [MEALS-CNT-ON-SECTION]) >= 2">
+                    <choiceState section="sect333" set="disabled" />
+                </test>
+            </onInventoryEvent>
+        </section>
+
+        <section id="sect59">
+            <pick class="arrow" count="-1" />
+        </section>
+
+        <section id="sect60">
+            <combat noMindblast="true" />
+        </section>
+
+        <section id="sect62">
+            <object objectId="rope" price="3" />
+            <object objectId="blanket" price="2" />
+            <object objectId="hourglass" price="3" />
+            <object objectId="tinderbox" price="2" />
+            <object objectId="spyglass" price="2" />
+        </section>
+
+        <section id="sect65">
+            <choiceState section="sect317" set="disabled" />
+            <test hasDiscipline="herbmst">
+                <choiceState section="sect317" set="enabled" />
+                <choiceState section="sect228" set="disabled" />
+            </test>
+        </section>
+
+        <section id="sect66">
+            <choiceState section="sect229" set="disabled" />
+            <choiceState section="sect339" set="disabled" />
+            <test hasDiscipline="gnosis">
+                <choiceState section="sect229" set="enabled" />
+            </test>
+            <test hasDiscipline="hntmstry">
+                <choiceState section="sect339" set="enabled" />
+            </test>
+        </section>
+
+        <section id="sect67">
+            <choiceState section="sect226" set="disabled" />
+            <test hasDiscipline="element">
+                <choiceState section="sect226" set="enabled" />
+                <choiceState section="sect55" set="disabled" />
+            </test>
+        </section>
+
+        <section id="sect68">
+            <choiceState section="all" set="disabled" />
+            <test hasDiscipline="alchemy">
+                <choiceState section="sect141" set="enabled" />
+            </test>
+            <test hasDiscipline="anmlmstr">
+                <choiceState section="sect168" set="enabled" />
+            </test>
+            <test canUseBow="true">
+                <choiceState section="sect326" set="enabled" />
+            </test>  
+            <choiceState section="sect53" set="enabled" />      
+        </section>
+
+        <section id="sect70">
+            <endurance count="-10" />
+        </section>
+
+        <section id="sect72">
+            <choiceState section="sect345" set="disabled" />
+            <test canUseBow="true">
+                <choiceState section="sect345" set="enabled" />
+            </test>  
+        </section>
+
+        <section id="sect75">
+            <choiceState section="sect101" set="disabled" />
+            <test canUseBow="true">
+                <choiceState section="sect101" set="enabled" />
+            </test>  
+        </section>
+
+        <section id="sect77">
+            <test expression="([MONEY]) >= 7">
+                <choiceState section="sect253" set="enabled" />
+                <choiceState section="sect164" set="disabled" />
+            </test>
+            <test not="true" expression="([MONEY]) >= 7">
+                <choiceState section="sect253" set="disabled" />
+                <choiceState section="sect164" set="enabled" />
+            </test>
+        </section>
+
+        <section id="sect78">
+            <choiceState section="all" set="disabled" />
+            <test hasDiscipline="magi">
+                <choiceState section="sect192" set="enabled" />
+            </test>
+            <test hasDiscipline="alchemy">
+                <choiceState section="sect257" set="enabled" />
+            </test>
+            <test hasDiscipline="element">
+                <choiceState section="sect308" set="enabled" />
+            </test>
+            <choiceState section="sect292" set="enabled" />
+        </section>
+
+        <section id="sect79">
+            <!-- TODO: Update prices from another section -->
+        </section>
+
+        <section id="sect80">
+            <test hasObject="cowana">
+                <choiceState section="sect243" set="enabled" />
+                <choiceState section="sect225" set="disabled" />
+            </test>
+            <test not="true" hasObject="cowana">
+                <choiceState section="sect243" set="disabled" />
+                <choiceState section="sect225" set="enabled" />
+            </test>
+        </section>
+
+        <section id="sect82">
+            <drop objectId="bow" />
+        </section>
+
+        <section id="sect83">
+            <drop backpackItemSlots="1" />
+            <choiceState section="all" set="disabled" />
+            <test hasDiscipline="alchemy">
+                <choiceState section="sect30" set="enabled" />
+            </test>
+            <test hasDiscipline="bardsman">
+                <choiceState section="sect286" set="enabled" />
+            </test>
+            <choiceState section="sect318" set="enabled" />
+        </section>
+
+        <section id="sect84">
+            <endurance count="-2" />
+        </section>
+
+        <section id="sect87">
+            <test hasDiscipline="alchemy">
+                <choiceState section="sect107" set="enabled" />
+                <choiceState section="sect115" set="disabled" />
+            </test>
+            <test not="true" hasDiscipline="alchemy">
+                <choiceState section="sect107" set="disabled" />
+                <choiceState section="sect115" set="enabled" />
+            </test>
+        </section>
+
+        <section id="sect89">
+            <test hasObject="ironskull">
+                <choiceState section="sect237" set="enabled" />
+                <choiceState section="sect332" set="disabled" />
+            </test>
+            <test not="true" hasObject="ironskull">
+                <choiceState section="sect237" set="disabled" />
+                <choiceState section="sect332" set="enabled" />
+            </test>
+        </section>
+
+        <section id="sect91">
+            <choiceState section="all" set="disabled" />
+
+            <randomTable>
+                <case from="0" to="3">
+                    <choiceState section="sect304" set="enabled" />
+                </case>
+                <case from="4">
+                    <choiceState section="sect193" set="enabled" />
+                </case>
+            </randomTable>
+            <test expression="[ENDURANCE] >= 20">
+                <randomTableIncrement increment="2" />
+            </test>
+        </section>
+
+        <section id="sect92">
+            <test hasDiscipline="anmlmstr">
+                <choiceState section="sect153" set="enabled" />
+                <choiceState section="sect280" set="disabled" />
+            </test>
+            <test not="true" hasDiscipline="anmlmstr">
+                <choiceState section="sect153" set="disabled" />
+                <choiceState section="sect280" set="enabled" />
+            </test>
+        </section>
+
+        <section id="sect94">
+            <choiceState section="all" set="disabled" />
+
+            <combat immuneTurns="1" noMindblast="true" />
+            <afterCombats>
+                <test combatsWon="true">
+                    <choiceState section="sect41" set="enabled" />
+                </test>
+            </afterCombats>
+        </section>
+
+        <section id="sect95">
+            <test expression="([MONEY]) &lt; 1">
+                <choiceState section="sect69" set="disabled" />
+            </test>
+            <choiceSelected section="sect69">
+                <pick class="money" count="-1" />
+            </choiceSelected>
+        </section>
+
+        <section id="sect96">
+            <test expression="([MONEY]) &lt; 3">
+                <choiceState section="sect183" set="disabled" />
+            </test>
+        </section>
+
+        <section id="sect97">
+            <choiceState section="all" set="disabled" />
+            <test hasDiscipline="magi">
+                <choiceState section="sect303" set="enabled" />
+            </test>
+            <test hasDiscipline="element">
+                <choiceState section="sect210" set="enabled" />
+            </test>
+            <choiceState section="sect162" set="enabled" />
+        </section>
+
+        <section id="sect98">
+            <choiceState section="all" set="disabled" />
+
+            <randomTable>
+                <case from="0" to="4">
+                    <choiceState section="sect57" set="enabled" />
+                </case>
+                <case from="5">
+                    <choiceState section="sect312" set="enabled" />
+                </case>
+            </randomTable>
+            <test expression="[ENDURANCE] >= 20">
+                <randomTableIncrement increment="2" />
+            </test>
+            <test expression="[ENDURANCE] &lt;= 10">
+                <randomTableIncrement increment="-2" />
+            </test>
+            <test hasDiscipline="hntmstry">
+                <randomTableIncrement increment="2" />
+            </test>
+        </section>
+
+        <section id="sect99">
+            <meal />
+        </section>
+    </sections>
+</mechanics>

--- a/www/data/mechanics-21.xml
+++ b/www/data/mechanics-21.xml
@@ -215,16 +215,18 @@
         <section id="sect34">
             <test expression="([MONEY]) &lt; 2">
                 <choiceState section="all" set="disabled" />
+                <message id="msg-drop-object" text="Drop one item of your choice to pay for a Standard room before continuing" />
 
                 <onInventoryEvent>
                     <test expression="[BACKPACK-ITEMS-CNT-ON-SECTION] > 0 || [WEAPON-ITEMS-CNT-ON-SECTION] > 0 || [SPECIAL-ITEMS-ON-SECTION] > 0">
+                        <message id="msg-drop-object" op="hide" />
                         <choiceState section="sect216" set="enabled" />
                     </test>
                     <test expression="[BACKPACK-ITEMS-CNT-ON-SECTION] == 0 &amp;&amp; [WEAPON-ITEMS-CNT-ON-SECTION] == 0 &amp;&amp; [SPECIAL-ITEMS-ON-SECTION] == 0">
+                        <message id="msg-drop-object" op="show" />
                         <choiceState section="sect216" set="disabled" />
                     </test>
                 </onInventoryEvent>
-                <message id="msg-drop-object" text="Drop one item of your choice to pay for a Standard room" />
             </test>
         </section>
 
@@ -451,16 +453,14 @@
         </section>
 
         <section id="sect72">
-            <choiceState section="sect345" set="disabled" />
-            <test canUseBow="true">
-                <choiceState section="sect345" set="enabled" />
+            <test canUseBow="false">
+                <choiceState section="sect345" set="disabled" />
             </test>  
         </section>
 
         <section id="sect75">
-            <choiceState section="sect101" set="disabled" />
-            <test canUseBow="true">
-                <choiceState section="sect101" set="enabled" />
+            <test canUseBow="false">
+                <choiceState section="sect101" set="disabled" />
             </test>  
         </section>
 
@@ -505,6 +505,7 @@
         </section>
 
         <section id="sect82">
+            <saveInventoryState restorePoint="book21sect82BowConfiscated" objectsType="bow" />
             <drop objectId="bow" />
         </section>
 
@@ -771,7 +772,9 @@
         <section id="sect135">
             <choiceState section="sect334" set="disabled" />
             <afterCombats>
-                <choiceState section="sect334" set="enabled" />
+                <test combatsWon="true">
+                    <choiceState section="sect334" set="enabled" />
+                </test>
             </afterCombats>
         </section>
 
@@ -963,7 +966,9 @@
 
             <combat noMindblast="true" noKaiSurge="false" noPsiSurge="true" noKaiBlast="true" noKaiRay="true" combatSkillModifier="-3"/>
             <afterCombats>
-                <choiceState section="all" set="enabled" />
+                <test combatsWon="true">
+                    <choiceState section="all" set="enabled" />
+                </test>
             </afterCombats>
         </section>
 
@@ -1149,7 +1154,7 @@
 
         <section id="sect190">
             <endurance count="-3" />
-            <message id="msg-drop-object" text="Drop two items of your choice from your Backpack Items list" />
+            <message id="msg-drop-object" text="Drop two items of your choice from your Backpack Items list before continuing" />
             <onInventoryEvent>
                 <test expression="[BACKPACK-ITEMS-CNT-ON-ACTIONCHART] == 0 || [BACKPACK-ITEMS-CNT-ON-SECTION] >= 2">
                     <message id="msg-drop-object" op="hide" />
@@ -1230,11 +1235,105 @@
             <choiceState section="sect260" set="enabled" />
         </section>
 
+        <section id="sect201">
+            <sell class="special" price="20" objectId="siyencrown" />
+            <sell class="special" price="10" objectId="ironskull" />
+            <sell class="special" price="30" objectId="kutyanemerald" />
+        </section>
 
+        <section id="sect204">
+            <choiceState section="all" set="disabled" />
 
+            <endurance count="-2" />
+            <combat noMindblast="true" />
 
+            <afterCombats>
+                <test combatsWon="true">
+                    <choiceState section="all" set="enabled" />
+                </test>
+            </afterCombats>
+        </section>
 
+        <section id="sect205">
+            <choiceState section="sect158" set="disabled" />
+            <test hasDiscipline="alchemy">
+                <choiceState section="sect158" set="enabled" />
+                <choiceState section="sect247" set="disabled" />
+            </test>
+        </section>
 
+        <section id="sect208">
+            <choiceState section="all" set="disabled" />
+
+            <message id="msg-drop-object" text="Drop one item of your choice from your Backpack Items list, or a Weapon if you do not possess any Backpack Items" />
+            <onInventoryEvent>
+                <test expression="[BACKPACK-ITEMS-CNT-ON-SECTION] > 0 || ([BACKPACK-ITEMS-ON-ACTIONCHART] == 0 &amp;&amp; [WEAPON-ITEMS-CNT-ON-SECTION] > 0)">
+                    <message id="msg-drop-object" op="hide" />
+                    <choiceState section="all" set="enabled" />
+                </test>
+                <test not="true" expression="[BACKPACK-ITEMS-CNT-ON-SECTION] > 0 || ([BACKPACK-ITEMS-ON-ACTIONCHART] == 0 &amp;&amp; [WEAPON-ITEMS-CNT-ON-SECTION] > 0)">
+                    <message id="msg-drop-object" op="show" />
+                    <choiceState section="all" set="disabled" />
+                </test>
+            </onInventoryEvent>
+        </section>
+
+        <section id="sect209">
+            <endurance count="-2" />
+        </section>
+
+        <section id="sect210">
+            <choiceState section="all" set="disabled" />
+            <combat noWeapon="true" noMindblast="true" noKaiBlast="true" noKaiRay="true" noPsiSurge="true" />
+
+            <afterCombats>
+                <test combatsWon="true">
+                    <choiceState section="all" set="enabled" />
+                </test>
+            </afterCombats>
+        </section>
+
+        <section id="sect211">
+            <test not="true" hasDiscipline="element">
+                <choiceState section="sect157" set="disabled" />
+            </test>
+            <test not="true" hasDiscipline="nexus">
+                <choiceState section="sect283" set="disabled" />
+            </test>
+        </section>
+
+        <section id="sect212">
+            <choiceState section="all" set="disabled" />
+            <randomTable>
+                <case from="0" to="2">
+                    <choiceState section="sect238" set="enabled" />
+                </case>
+                <case from="3" to="6">
+                    <choiceState section="sect84" set="enabled" />
+                </case>
+                <case from="7">
+                    <choiceState section="sect284" set="enabled" />
+                </case>
+            </randomTable>
+            <test hasDiscipline="assimila">
+                <randomTableIncrement increment="3" />
+            </test>
+            <test expression="[ENDURANCE] &lt;= 20">
+                <randomTableIncrement increment="-2" />
+            </test>
+        </section>
+
+        <section id="sect213">
+            <meal />
+        </section>
+
+        <section id="sect214">
+            <pick class="money" count="7" />
+        </section>
+
+        <section id="sect215">
+            <object objectId="kutyanemerald" />
+        </section>
 
         <section id="sect216">
             <pick class="money" count="-2" />
@@ -1247,7 +1346,430 @@
                     <choiceState section="sect194" set="enabled" />
                 </case>
             </randomTable>
-
         </section>
+
+        <section id="sect218">
+            <choiceState section="sect107" set="disabled" />
+            <test hasDiscipline="alchemy">
+                <choiceState section="sect107" set="enabled" />
+                <choiceState section="sect115" set="disabled" />
+            </test>
+        </section>
+
+        <section id="sect219">
+            <pick class="money" count="-1" />
+        </section>
+
+        <section id="sect220">
+            <test not="true" hasDiscipline="alchemy">
+                <choiceState section="sect141" set="disabled" />
+            </test>
+            <test not="true" hasDiscipline="anmlmstr">
+                <choiceState section="sect168" set="disabled" />
+            </test>
+            <test canUseBow="false">
+                <choiceState section="sect326" set="disabled" />
+            </test>
+        </section>
+
+        <section id="sect224">
+            <choiceState section="sect317" set="disabled" />
+            <test hasDiscipline="herbmst">
+                <choiceState section="sect317" set="enabled" />
+                <choiceState section="sect228" set="disabled" />
+            </test>
+        </section>
+
+        <section id="sect225">
+            <endurance count="-6" />
+        </section>
+
+        <section id="sect227">
+            <endurance count="-2" />
+        </section>
+
+        <section id="sect230">
+            <choiceState section="all" set="disabled" />
+            <combat noWeapon="1" />
+            <afterCombats>
+                <test combatsWon="true">
+                    <choiceState section="all" set="enabled" />
+                </test>
+            </afterCombats>
+        </section>
+
+        <section id="sect231">
+            <endurance count="-2" />
+        </section>
+
+        <section id="sect232">
+            <pick class="money" count="-10" />
+            <choiceState section="sect329" set="disabled" />
+            <test hasDiscipline="gnosis">
+                <choiceState section="sect329" set="enabled" />
+                <choiceState section="sect301" set="disabled" />
+            </test>            
+        </section>
+
+        <section id="sect233">
+            <drop backpackItemSlots="last" />
+            <choiceState section="sect85" set="disabled" />
+            <test hasDiscipline="alchemy">
+                <choiceState section="sect85" set="enabled" />
+                <choiceState section="sect98" set="disabled" />
+            </test>    
+        </section>
+
+        <section id="sect238">
+            <endurance count="-5" />
+            <test canUseBow="false">
+                <choiceState section="sect136" set="disabled" />
+            </test>  
+        </section>
+
+        <section id="sect239">
+            <endurance count="-3" />
+        </section>
+
+        <section id="sect241">
+            <meal />
+        </section>
+
+        <section id="sect242">
+            <object objectId="meal" index="0" />
+            <object objectId="meal" index="1" />
+        </section>
+
+        <section id="sect243">
+            <drop objectId="cowana"/>
+            <endurance count="-3" />
+        </section>
+
+        <section id="sect244">
+            <choiceState section="all" set="disabled" />
+            <pick class="arrow" count="-1"/>
+
+            <randomTable>
+                <case from="0" to="5">
+                    <choiceState section="sect71" set="enabled" />
+                </case>
+                <case from="6">
+                    <choiceState section="sect49" set="enabled" />
+                </case>
+            </randomTable>
+            <test hasWeaponskillWith="bow">
+                <randomTableIncrement increment="5" />
+            </test>
+        </section>
+
+        <section id="sect246">
+            <endurance count="-4" />
+        </section>
+
+        <section id="sect248">
+            <endurance count="-2" />
+
+            <choiceState section="all" set="disabled" />
+            <combat noMindblast="true" />
+            <afterCombats>
+                <test combatsWon="true">
+                    <choiceState section="all" set="enabled" />
+                </test>
+            </afterCombats>
+        </section>
+
+        <section id="sect249">
+            <object objectId="meal" index="0" />
+            <object objectId="meal" index="1" />
+        </section>
+
+        <section id="sect251">
+            <test expression="[MONEY] == 0">
+                <choiceState section="sect182" set="disabled" />
+            </test>
+            <test expression="[BACKPACK-ITEMS-CNT-ON-ACTIONCHART] == 0">
+                <choiceState section="sect277" set="disabled" />
+            </test>
+            <test expression="[SPECIAL-ITEMS-ON-ACTIONCHART] == 0">
+                <choiceState section="sect103" set="disabled" />
+            </test>
+            <test expression="[MONEY] == 0 &amp;&amp; [BACKPACK-ITEMS-CNT-ON-ACTIONCHART] == 0 &amp;&amp; [SPECIAL-ITEMS-ON-ACTIONCHART] == 0">
+                <textToChoice text="turning to 321" section="sect321" />
+            </test>
+        </section>
+
+        <section id="sect253">
+            <pick class="money" count="-7" />
+            <object objectId="meal" unlimited="true" price="2" />
+        </section>
+
+        <section id="sect256">
+            <choiceState section="sect85" set="disabled" />
+            <test hasDiscipline="alchemy">
+                <choiceState section="sect85" set="enabled" />
+                <choiceState section="sect98" set="disabled" />
+            </test>
+        </section>
+
+        <section id="sect257">
+            <choiceState section="all" set="disabled" />
+
+            <combat combatSkillModifier="2" />
+            <afterCombatTurn turn="1">
+                <combat combatSkillModifier="+0" />
+            </afterCombatTurn>
+            <afterCombats>
+                <test combatsWon="true">
+                    <choiceState section="all" set="enabled" />
+                </test>
+            </afterCombats>
+        </section>
+
+        <section id="sect260">
+            <choiceState section="all" set="disabled" />
+            <randomTable>
+                <case from="0" to="3">
+                    <choiceState section="sect120" set="enabled" />
+                </case>
+                <case from="4" to="6">
+                    <choiceState section="sect43" set="enabled" />
+                </case>
+                <case from="7">
+                    <choiceState section="sect60" set="enabled" />
+                </case>
+            </randomTable>
+            <test hasDiscipline="hntmstry">
+                <randomTableIncrement increment="1" />
+            </test>
+            <test expression="[ENDURANCE] >= 20">
+                <randomTableIncrement increment="1" />
+            </test>
+            <test expression="[ENDURANCE] &lt;= 15">
+                <randomTableIncrement increment="-1" />
+            </test>
+        </section>
+
+        <section id="sect261">
+            <choiceState section="all" set="disabled" />
+            <combat combatSkillModifier="2"/>
+            <afterCombatTurn turn="1">
+                <combat combatSkillModifier="0"/>
+            </afterCombatTurn>
+            <afterCombats>
+                <test combatsWon="true">
+                    <choiceState section="all" set="enabled" />
+                </test>
+            </afterCombats>
+        </section>
+
+        <section id="sect262">
+            <meal />
+        </section>
+
+        <section id="sect263">
+            <choiceState section="all" set="disabled" />
+            <randomTable>
+                <case from="0" to="3">
+                    <choiceState section="sect335" set="enabled" />
+                </case>
+                <case from="4" to="6">
+                    <choiceState section="sect27" set="enabled" />
+                </case>
+                <case from="7">
+                    <choiceState section="sect190" set="enabled" />
+                </case>
+            </randomTable>
+        </section>
+
+        <section id="sect266">
+            <endurance count="-2" />
+            <choiceState section="all" set="disabled" />
+            <combat noMindblast="true "/>
+            <afterCombats>
+                <test combatsWon="true">
+                    <choiceState section="all" set="enabled" />
+                </test>
+            </afterCombats>
+        </section>
+
+        <section id="sect268">
+            <pick class="money" count="20" />
+            <restoreInventoryState restorePoint="book21sect82BowConfiscated" />
+        </section>
+
+        <section id="sect269">
+            <choiceState section="sect197" set="disabled" />
+            <test hasDiscipline="element">
+                <choiceState section="sect197" set="enabled" />
+                <choiceState section="sect51" set="disabled" />
+            </test>
+        </section>
+
+        <section id="sect270">
+            <choiceState section="all" set="disabled" />
+            <randomTable>
+                <case from="0" to="3">
+                    <choiceState section="sect112" set="enabled" />
+                </case>
+                <case from="4" to="7">
+                    <choiceState section="sect9" set="enabled" />
+                </case>
+                <case from="8">
+                    <choiceState section="sect259" set="enabled" />
+                </case>
+            </randomTable>
+            <test hasDiscipline="hntmstry">
+                <randomTableIncrement increment="2" />
+            </test>
+        </section>
+
+        <section id="sect272">
+            <pick class="money" count="7" />
+        </section>
+
+        <section id="sect276">
+            <endurance count="-5" />
+        </section>
+
+        <section id="sect277">
+            <message id="msg-drop-object" text="Drop Backpack Items of your choice to restore Endurance points" />
+            <choiceSelected section="sect34">
+                <endurance count="[BACKPACK-ITEMS-CNT-ON-SECTION] * 3" />
+            </choiceSelected>
+        </section>
+
+        <section id="sect278">
+            <choiceState section="sect42" set="disabled" />
+            <test hasDiscipline="hntmstry">
+                <choiceState section="sect42" set="enabled" />
+                <choiceState section="sect306" set="disabled" />
+            </test>
+        </section>
+
+        <section id="sect279">
+            <endurance count="-2" />
+            <choiceState section="all" set="disabled" />
+            <combat noMindblast="true "/>
+            <afterCombats>
+                <test combatsWon="true">
+                    <choiceState section="all" set="enabled" />
+                </test>
+            </afterCombats>
+        </section>
+
+        <section id="sect280">
+            <choiceState section="all" set="disabled" />
+            <randomTable>
+                <case from="0" to="5">
+                    <choiceState section="sect231" set="enabled" />
+                </case>
+                <case from="6">
+                    <choiceState section="sect80" set="enabled" />
+                </case>
+            </randomTable>
+        </section>
+
+        <section id="sect282">
+            <test not="true" expression="[MONEY] >= 2">
+                <choiceState section="sect140" set="disabled" />
+            </test>
+            <choiceSelected section="sect140">
+                <pick class="money" count="-2" />
+            </choiceSelected>
+        </section>
+
+        <section id="sect283">
+            <choiceState section="all" set="disabled" />
+            <randomTable>
+                <case from="0" to="4">
+                    <choiceState section="sect218" set="enabled" />
+                </case>
+                <case from="5">
+                    <choiceState section="sect307" set="enabled" />
+                </case>
+            </randomTable>
+            <test expression="[ENDURANCE] >= 25">
+                <randomTableIncrement increment="2" />
+            </test>
+            <test expression="[ENDURANCE] &lt;= 10">
+                <randomTableIncrement increment="-1" />
+            </test>
+        </section>
+
+        <section id="sect288">
+            <test not="true" hasDiscipline="alchemy">
+                <choiceState section="sect46" set="disabled" />
+            </test>
+        </section>
+
+        <section id="sect291">
+            <pick class="money" count="-3" />
+        </section>
+
+        <section id="sect292">
+            <choiceState section="all" set="disabled" />
+            <randomTable>
+                <case from="0" to="4">
+                    <choiceState section="sect44" set="enabled" />
+                </case>
+                <case from="5">
+                    <choiceState section="sect261" set="enabled" />
+                </case>
+            </randomTable>
+            <test expression="[ENDURANCE] &lt;= 20">
+                <randomTableIncrement increment="-2" />
+            </test>
+        </section>
+
+        <section id="sect296">
+            <endurance count="-1" />
+        </section>
+
+        <section id="sect297">
+            <choiceState section="all" set="disabled" />
+            <randomTable>
+                <case from="0" to="4">
+                    <choiceState section="sect248" set="enabled" />
+                </case>
+                <case from="5">
+                    <choiceState section="sect94" set="enabled" />
+                </case>
+            </randomTable>
+        </section>
+
+        <section id="sect298">
+            <sell class="special" price="20" objectId="siyencrown" />
+            <sell class="special" price="10" objectId="ironskull" />
+            <sell class="special" price="30" objectId="kutyanemerald" />
+        </section>
+
+        <section id="sect299">
+            <test not="true" hasDiscipline="magi">
+                <choiceState section="sect303" set="disabled" />
+            </test>
+            <test not="true" hasDiscipline="element">
+                <choiceState section="sect210" set="disabled" />
+            </test>
+        </section>
+
+        <section id="sect300">
+            <choiceState section="all" set="disabled" />
+            <combat noMindblast="true" />
+            <afterCombats>
+                <test combatsWon="true">
+                    <choiceState section="all" set="enabled" />
+                </test>
+            </afterCombats>
+        </section>
+
+        <section id="sect322">
+            <pick class="arrow" count="-1" />
+        </section>
+
+        <section id="sect349">
+            <meal />
+        </section>
+
+
     </sections>
 </mechanics>

--- a/www/data/mechanics-21.xml
+++ b/www/data/mechanics-21.xml
@@ -296,6 +296,7 @@
         </section>
 
         <section id="sect40">
+            <!-- TODO: Would be cool to add a timer here for the player to start the countdown -->
             <numberPicker text="Answer the riddle" min="1" max="350" actionButton="Choose" />
             <numberPickerChoosed>
                 <test expression="[NUMBERPICKER] == 23">
@@ -410,6 +411,19 @@
                 <choiceState section="sect115" set="disabled" />
             </test>
         </section>
+
+        <section id="sect54">
+            <choiceState section="all" set="disabled" />
+            <test hasObject="ironskull">
+                <choiceState section="sect201" set="enabled" />
+            </test>
+            <test hasObject="siyencrown">
+                <choiceState section="sect134" set="enabled" />
+            </test>
+            <test hasObject="kutyanemerald">
+                <choiceState section="sect298" set="enabled" />
+            </test>
+       </section>
 
         <section id="sect55">
             <choiceState section="all" set="disabled" />
@@ -573,7 +587,6 @@
         </section>
 
         <section id="sect83">
-            <drop backpackItemSlots="1" />
             <choiceState section="all" set="disabled" />
             <test hasDiscipline="alchemy">
                 <choiceState section="sect30" set="enabled" />
@@ -1896,6 +1909,10 @@
             <object objectId="cowana" index="0" />
             <object objectId="cowana" index="1" />
             <object objectId="cowana" index="2" />
+        </section>
+
+        <section id="sect318">
+            <drop backpackItemSlots="1" />
         </section>
 
         <section id="sect319">

--- a/www/data/mechanics-21.xml
+++ b/www/data/mechanics-21.xml
@@ -114,6 +114,7 @@
         </section>
 
         <section id="sect7">
+            <choiceState section="sect221" set="disabled" />
             <test not="true" sectionVisited="sect79">
                 <object objectId="laumspurpotion4" price="3" />
                 <object objectId="potionofstrength" price="3" />
@@ -126,6 +127,12 @@
                 <object objectId="mustowpotion" price="2" />
                 <object objectId="sebarispotion" price="2" />
             </test>
+            <onInventoryEvent>
+                <test pickedSomethingOnSection="sect7">
+                    <choiceState section="sect221" set="enabled" />
+                    <choiceState section="sect79" set="disabled" />
+                </test>
+            </onInventoryEvent>
         </section>
 
         <section id="sect8">
@@ -984,7 +991,7 @@
                 </case>
             </randomTable>
             <test hasDiscipline="anmlmstr">
-                <randomTableIncrement increment="5" />
+                <randomTableIncrement increment="3" />
             </test>
         </section>
 

--- a/www/data/mechanics-21.xml
+++ b/www/data/mechanics-21.xml
@@ -548,6 +548,10 @@
             <choiceState section="sect292" set="enabled" />
         </section>
 
+        <section id="sect79">
+            <resetSectionState sectionId="sect7" />
+        </section>
+
         <section id="sect80">
             <test hasObject="cowana">
                 <choiceState section="sect243" set="enabled" />

--- a/www/data/mechanics-21.xml
+++ b/www/data/mechanics-21.xml
@@ -62,10 +62,33 @@
         </section>
 
         <section id="sect5">
+            <choiceState section="all" set="disabled" />
+
             <combat noWeapon="true" />
             <afterCombatTurn turn="1">
                 <combat noWeapon="false" />
             </afterCombatTurn>
+
+            <afterCombats>
+                <test combatsWon="true">
+                    <choiceState section="all" set="enabled" />
+                </test>
+            </afterCombats>
+        </section>
+
+        <section id="sect7">
+            <test not="true" sectionVisited="sect79">
+                <object objectId="laumspurpotion4" price="3" />
+                <object objectId="potionofstrength" price="3" />
+                <object objectId="mustowpotion" price="3" />
+                <object objectId="sebarispotion" price="3" />
+            </test>
+            <test sectionVisited="sect79">
+                <object objectId="laumspurpotion4" price="2" />
+                <object objectId="potionofstrength" price="2" />
+                <object objectId="mustowpotion" price="2" />
+                <object objectId="sebarispotion" price="2" />
+            </test>
         </section>
 
         <section id="sect8">
@@ -190,7 +213,19 @@
         </section>
 
         <section id="sect34">
-            <!-- TODO: Barter for room -->
+            <test expression="([MONEY]) &lt; 2">
+                <choiceState section="all" set="disabled" />
+
+                <onInventoryEvent>
+                    <test expression="[BACKPACK-ITEMS-CNT-ON-SECTION] > 0 || [WEAPON-ITEMS-CNT-ON-SECTION] > 0 || [SPECIAL-ITEMS-ON-SECTION] > 0">
+                        <choiceState section="sect216" set="enabled" />
+                    </test>
+                    <test expression="[BACKPACK-ITEMS-CNT-ON-SECTION] == 0 &amp;&amp; [WEAPON-ITEMS-CNT-ON-SECTION] == 0 &amp;&amp; [SPECIAL-ITEMS-ON-SECTION] == 0">
+                        <choiceState section="sect216" set="disabled" />
+                    </test>
+                </onInventoryEvent>
+                <message id="msg-drop-object" text="Drop one item of your choice to pay for a Standard room" />
+            </test>
         </section>
 
         <section id="sect36">
@@ -201,7 +236,7 @@
             <choiceState section="sect272" set="disabled" />
 
             <test hasDiscipline="bardsman">
-                <test hasObject="flute">
+                <test hasObject="flute|lyre">
                     <choiceState section="sect272" set="enabled" />
                     <choiceState section="sect8" set="disabled" />
                 </test>
@@ -209,7 +244,15 @@
         </section>
 
         <section id="sect40">
-               <!-- TODO: Link to answer -->
+            <numberPicker text="Answer the riddle" min="1" max="350" actionButton="Choose" />
+            <numberPickerChoosed>
+                <test expression="[NUMBERPICKER] == 23">
+                    <goToSection section="sect23" />
+                </test>
+                <test expression="[NUMBERPICKER] != 23">
+                    <toast text="Wrong number!" />
+                </test>
+            </numberPickerChoosed>
         </section>
 
         <section id="sect42">
@@ -265,21 +308,33 @@
         <section id="sect51">
             <choiceState section="all" set="disabled" />
 
-            <randomTable>
-                <case from="0" to="1">
-                    <choiceState section="sect342" set="enabled" />
-                </case>
-                <case from="2" to="7">
-                    <choiceState section="sect15" set="enabled" />
-                </case>
-                <case from="8">
-                    <choiceState section="sect203" set="enabled" />
-                </case>
-            </randomTable>
-            <test hasDiscipline="hntmstry">
-                <randomTableIncrement increment="3" />
-                <!-- TODO: Allow player to deduct EP to increase their roll -->
-            </test>
+            <choiceState section="all" set="disabled" />
+            <numberPicker 
+            text="Choose the number of Endurance Points you are prepared to deduct"
+            min="0" 
+            actionButton="Choose"
+            />
+            <numberPickerChoosed executeAtStart="true">
+                <numberPicker enabled="false" />
+                <endurance count="-[NUMBERPICKER]" />
+
+                <randomTable>
+                    <case from="0" to="1">
+                        <choiceState section="sect342" set="enabled" />
+                    </case>
+                    <case from="2" to="7">
+                        <choiceState section="sect15" set="enabled" />
+                    </case>
+                    <case from="8">
+                        <choiceState section="sect203" set="enabled" />
+                    </case>
+                </randomTable>
+
+                <test hasDiscipline="hntmstry">
+                    <randomTableIncrement increment="3" />
+                </test>
+                <randomTableIncrement increment="[NUMBERPICKER]" />
+            </numberPickerChoosed>
         </section>
 
         <section id="sect52">
@@ -426,10 +481,6 @@
             <choiceState section="sect292" set="enabled" />
         </section>
 
-        <section id="sect79">
-            <!-- TODO: Update prices from another section -->
-        </section>
-
         <section id="sect80">
             <test hasObject="cowana">
                 <choiceState section="sect243" set="enabled" />
@@ -571,6 +622,619 @@
 
         <section id="sect99">
             <meal />
+        </section>
+
+        <section id="sect102">
+            <pick objectId="temujunsring" />
+        </section>
+
+        <section id="sect103">
+            <message id="msg-drop-object" text="Drop Special Items of your choice to restore Endurance points" />
+            <onInventoryEvent>
+                <test objectOnSection="moonstone|ironskull">
+                    <choiceState section="all" set="disabled" />
+                </test>
+                <test not="true" objectOnSection="moonstone|ironskull">
+                    <choiceState section="all" set="enabled" />
+                </test>
+            </onInventoryEvent>
+            <choiceSelected section="sect34">
+                <endurance count="[SPECIAL-ITEMS-ON-SECTION] * 6" />
+            </choiceSelected>
+        </section>
+
+        <section id="sect104">
+            <meal />
+        </section>
+
+        <section id="sect108">
+            <object objectId="ironskull" />
+        </section>
+
+        <section id="sect109">
+            <endurance count="-3" />
+            <meal />
+        </section>
+
+        <section id="sect111">
+            <choiceState section="sect85" set="disabled" />
+            <test hasDiscipline="alchemy">
+                <choiceState section="sect85" set="enabled" />
+                <choiceState section="sect98" set="disabled" />
+            </test>
+        </section>
+
+        <section id="sect112">
+            <endurance count="-3" />
+        </section>
+
+        <section id="sect117">
+            <object objectId="siyencrown" />
+        </section>
+
+        <section id="sect119">
+            <choiceState section="sect288" set="disabled" />
+            <test hasDiscipline="pthmnshp">
+                <test hasDiscipline="gnosis">
+                    <choiceState section="sect288" set="enabled" />
+                    <choiceState section="sect129" set="disabled" />
+                </test>
+            </test>
+        </section>
+
+        <section id="sect120">
+            <combat noMindblast="true" />
+        </section>
+
+        <section id="sect121">
+            <test not="true" hasDiscipline="magi">
+                <choiceState section="sect303" set="disabled" />
+            </test>
+            <test not="true" hasDiscipline="element">
+                <choiceState section="sect210" set="disabled" />
+            </test>
+        </section>
+
+        <section id="sect122">
+            <endurance count="-2" />
+        </section>
+ 
+        <section id="sect125">
+            <choiceState section="sect215" set="disabled" />
+            <test hasDiscipline="alchemy">
+                <choiceState section="sect215" set="enabled" />
+                <choiceState section="sect130" set="disabled" />
+            </test>
+        </section>
+
+        <section id="sect126">
+            <choiceState section="all" set="disabled" />
+
+            <randomTable>
+                <case from="0" to="2">
+                    <choiceState section="sect238" set="enabled" />
+                </case>
+                <case from="3" to="6">
+                    <choiceState section="sect84" set="enabled" />
+                </case>
+                <case from="7">
+                    <choiceState section="sect284" set="enabled" />
+                </case>
+            </randomTable>
+            <test hasDiscipline="assimila">
+                <randomTableIncrement increment="3" />
+            </test>
+            <test expression="[ENDURANCE] &lt;= 20">
+                <randomTableIncrement increment="-2" />
+            </test>
+        </section>
+
+        <section id="sect127">
+            <pick class="money" count="-2" />
+        </section>
+
+        <section id="sect129">
+            <choiceState section="sect197" set="disabled" />
+            <test hasDiscipline="element">
+                <choiceState section="sect197" set="enabled" />
+                <choiceState section="sect51" set="disabled" />
+            </test>
+        </section>
+
+        <section id="sect132">
+            <object objectId="sword" />
+            <object objectId="dagger" />
+            <pick class="money" count="20" />
+            <endurance count="3" />
+            <object objectId="meal" />
+            <object objectId="meal" />
+        </section>
+
+        <section id="sect134">
+            <sell class="special" price="20" objectId="siyencrown" />
+            <sell class="special" price="10" objectId="ironskull" />
+            <sell class="special" price="30" objectId="kutyanemerald" />
+        </section>
+
+        <section id="sect135">
+            <choiceState section="sect334" set="disabled" />
+            <afterCombats>
+                <choiceState section="sect334" set="enabled" />
+            </afterCombats>
+        </section>
+
+        <section id="sect136">
+            <choiceState section="all" set="disabled" />
+
+            <randomTable>
+                <case from="0" to="4">
+                    <choiceState section="sect320" set="enabled" />
+                </case>
+                <case from="5">
+                    <choiceState section="sect296" set="enabled" />
+                </case>
+            </randomTable>
+            <test hasWeaponskillWith="bow">
+                <randomTableIncrement increment="5" />
+            </test>
+            <test expression="[ENDURANCE] &lt;= 15">
+                <randomTableIncrement increment="-1" />
+            </test>
+        </section>
+        
+        <section id="137">
+            <meal />
+        </section>
+
+        <section id="sect138">
+            <pick class="money" count="-4" />
+            <choiceState section="all" set="disabled" />
+
+            <randomTable>
+                <case from="0" to="4">
+                    <choiceState section="sect330" set="enabled" />
+                </case>
+                <case from="5">
+                    <choiceState section="sect92" set="enabled" />
+                </case>
+            </randomTable>
+        </section>
+
+        <section id="sect142">
+            <!-- TODO: The three candles are purchased as one, should probably be a stack in the backpack -->
+            <object objectId="dagger" price="1" />
+            <object objectId="scentedoil" price="1" />
+            <object objectId="candle" price="1" count="3" />
+            <object objectId="slippers" price="1" />
+            <object objectId="coppercup" price="1" />
+            <object objectId="rope" price="1" />
+            <object objectId="lantern" price="1" />
+            <object objectId="lyre" price="1" />
+            <object objectId="ballofchalk" price="1" />
+            <object objectId="arrow" price="1" count="3" />
+        </section>
+
+        <section id="sect143">
+            <choiceState section="all" set="disabled" />
+            <onInventoryEvent>
+                <test expression="[BACKPACK-ITEMS-CNT-ON-SECTION] >= 2 || [WEAPON-ITEMS-CNT-ON-SECTION] > 0 || [SPECIAL-ITEMS-ON-SECTION] > 0">
+                    <choiceState section="all" set="enabled" />
+
+                </test>
+                <test expression="[BACKPACK-ITEMS-CNT-ON-SECTION] &lt; 2 &amp;&amp; [WEAPON-ITEMS-CNT-ON-SECTION] == 0 &amp;&amp; [SPECIAL-ITEMS-ON-SECTION] == 0">
+                    <choiceState section="all" set="disabled" />
+
+                </test>
+            </onInventoryEvent>
+        </section>
+
+        <section id="sect144">
+            <choiceState section="all" set="disabled" />
+
+            <randomTable>
+                <case from="0" to="3">
+                    <choiceState section="sect335" set="enabled" />
+                </case>
+                <case from="4" to="6">
+                    <choiceState section="sect27" set="enabled" />
+                </case>
+                <case from="7">
+                    <choiceState section="sect190" set="enabled" />
+                </case>
+            </randomTable>
+        </section>
+
+        <section id="sect149">
+            <pick class="money" count="2" />
+        </section>
+
+        <section id="sect150">
+            <choiceState section="sect133" set="disabled" />
+            <test hasDiscipline="astrolgy">
+                <choiceState section="sect133" set="enabled" />
+                <choiceState section="sect327" set="disabled" />
+            </test>
+        </section>
+
+        <section id="sect151">
+            <object objectId="broadsword" price="8" />
+            <object objectId="warhammer" price="7" />
+            <object objectId="dagger" price="3" />
+            <object objectId="axe" price="8" />
+            <object objectId="shortsword" price="4" />
+            <object objectId="arrow" price="1" unlimited="true" />
+        </section>
+
+        <section id="sect152">
+            <test not="true" expression="[MONEY] >= 20">
+                <choiceState section="sect37" set="disabled" />
+            </test>
+            <choiceSelected section="sect37">
+                <pick class="money" count="-20" />
+            </choiceSelected>
+        </section>
+
+        <section id="sect153">
+            <endurance count="-2" />
+        </section>
+
+        <section id="sect154">
+            <pick class="arrow" count="-1" />
+        </section>
+        
+        <section id="sect155">
+            <onInventoryEvent>
+                <test expression="[MONEY] >= 3">
+                    <choiceState section="sect291" set="enabled" />
+                    <choiceState section="sect214" set="disabled" />
+                </test>
+                <test expression="[MONEY] &lt; 3">
+                    <choiceState section="sect291" set="disabled" />
+                    <choiceState section="sect214" set="enabled" />
+                </test>
+            </onInventoryEvent>
+            <sell class="special" except="moonstone" price="10" />
+            <sell class="weapon" price="3" />
+            <sell class="object" price="1" />
+        </section>
+
+        <section id="sect156">
+            <choiceState section="all" set="disabled" />
+
+            <randomTable>
+                <case from="0" to="1">
+                    <choiceState section="sect276" set="enabled" />
+                </case>
+                <case from="2" to="6">
+                    <choiceState section="sect29" set="enabled" />
+                </case>
+                <case from="7">
+                    <choiceState section="sect86" set="enabled" />
+                </case>
+            </randomTable>
+            <test hasDiscipline="anmlmstr">
+                <randomTableIncrement increment="5" />
+            </test>
+        </section>
+
+        <section id="sect157">
+            <choiceState section="all" set="disabled" />
+
+            <randomTable>
+                <case from="0" to="4">
+                    <choiceState section="sect218" set="enabled" />
+                </case>
+                <case from="5">
+                    <choiceState section="sect307" set="enabled" />
+                </case>
+            </randomTable>
+            <test expression="[ENDURANCE] >= 20">
+                <randomTableIncrement increment="2" />
+            </test>
+        </section>
+
+        <section id="sect159">
+            <endurance count="2" />
+        </section>
+
+        <section id="sect160">
+            <choiceState section="sect265" set="disabled" />
+            <test hasDiscipline="deliver">
+                <choiceState section="sect265" set="enabled" />
+                <choiceState section="sect178" set="disabled" />
+            </test>
+        </section>
+
+        <section id="sect162">
+            <choiceState section="all" set="disabled" />
+
+            <combat noMindblast="true" noKaiSurge="false" noPsiSurge="true" noKaiBlast="true" noKaiRay="true" combatSkillModifier="-3"/>
+            <afterCombats>
+                <choiceState section="all" set="enabled" />
+            </afterCombats>
+        </section>
+
+        <section id="sect163">
+            <endurance count="-8" />
+        </section>
+
+        <section id="sect164">
+            <choiceState section="all" set="disabled" />
+            <onInventoryEvent>
+                <test expression="[BACKPACK-ITEMS-CNT-ON-SECTION] >= 2 || [WEAPON-ITEMS-CNT-ON-SECTION] >= 1">
+                    <choiceState section="all" set="enabled" />
+                </test>
+                <test expression="[BACKPACK-ITEMS-CNT-ON-SECTION] &lt; 2 &amp;&amp; [WEAPON-ITEMS-CNT-ON-SECTION] &lt; 1">
+                    <choiceState section="all" set="disabled" />
+                </test>
+                </onInventoryEvent>
+        </section>
+
+        <section id="sect165">
+            <choiceState section="sect202" set="disabled" />
+            <test hasDiscipline="kaiscrn">
+                <choiceState section="sect202" set="enabled" />
+                <choiceState section="sect319" set="disabled" />
+            </test>
+        </section>
+
+        <section id="sect166">
+            <choiceState section="all" set="disabled" />
+            <numberPicker 
+                text="Choose the number of Gold Crowns you are going to donate"
+                min="3" 
+                money="true"
+                actionButton="Choose"
+            />
+            <numberPickerChoosed executeAtStart="true">
+                <numberPicker enabled="false" />
+                <pick class="money" count="-[NUMBERPICKER]" />
+                <test expression="[NUMBERPICKER] >= 3">
+                    <choiceState section="sect89" set="enabled" />
+                </test>
+            </numberPickerChoosed>
+        </section>
+
+        <section id="sect168">
+            <choiceState section="sect107" set="disabled" />
+            <test hasDiscipline="alchemy">
+                <choiceState section="sect107" set="enabled" />
+                <choiceState section="sect115" set="disabled" />
+            </test>
+        </section>
+
+        <section id="sect170">
+            <pick class="arrow" count="-1" />
+            <choiceState section="all" set="disabled" />
+
+            <randomTable>
+                <case from="0" to="7">
+                    <choiceState section="sect348" set="enabled" />
+                </case>
+                <case from="8">
+                    <choiceState section="sect59" set="enabled" />
+                </case>
+            </randomTable>
+            <test hasWeaponskillWith="bow">
+                <randomTableIncrement increment="5" />
+            </test>
+        </section>
+
+        <section id="sect172">
+            <choiceState section="sect95" set="disabled" />
+            <test expression="[MONEY] >= 6">
+                <choiceState section="sect95" set="enabled" />
+            </test>
+            <choiceSelected section="sect95">
+                <pick class="money" count="-6" />
+            </choiceSelected>
+        </section>
+
+        <section id="sect173">
+            <choiceState section="all" set="disabled" />
+
+            <randomTable>
+                <case from="0" to="5">
+                    <choiceState section="sect231" set="enabled" />
+                </case>
+                <case from="6">
+                    <choiceState section="sect80" set="enabled" />
+                </case>
+            </randomTable>
+        </section>
+
+        <section id="sect174">
+            <numberPicker text="Answer the riddle" min="1" max="350" actionButton="Choose" />
+            <numberPickerChoosed>
+                <test expression="[NUMBERPICKER] == 125">
+                    <goToSection section="sect125" />
+                </test>
+                <test expression="[NUMBERPICKER] != 125">
+                    <toast text="Wrong number!" />
+                </test>
+            </numberPickerChoosed>
+        </section>
+
+        <section id="sect177">
+            <choiceState section="sect72" set="disabled" />
+            <test hasDiscipline="hntmstry|gnosis">
+                <choiceState section="sect72" set="enabled" />
+                <choiceState section="sect297" set="disabled" />
+            </test>
+        </section>
+
+        <section id="sect179">
+            <choiceState section="sect316" set="disabled" />
+                <test hasDiscipline="hntmstry">
+                    <test hasDiscipline="gnosis">
+                    <choiceState section="sect316" set="enabled" />
+                    <choiceState section="sect211" set="disabled" />
+                </test>
+            </test>
+        </section>
+
+        <section id="sect181">
+            <choiceState section="sect267" set="disabled" />
+            <test hasDiscipline="anmlmstr">
+                <choiceState section="sect267" set="enabled" />
+                <choiceState section="sect325" set="disabled" />
+            </test>
+        </section>
+
+        <section id="sect182">
+            <numberPicker 
+            text="Choose the number of Gold Crowns you would like to place"
+            min="1" 
+            money="true"
+            actionButton="Choose"
+            />
+            <numberPickerChoosed executeAtStart="true">
+                <numberPicker enabled="false" />
+                <pick class="money" count="-[NUMBERPICKER]" />
+                <endurance count="[NUMBERPICKER]" />
+            </numberPickerChoosed>
+        </section>
+
+        <section id="sect183">
+            <pick class="money" count="-3" />
+        </section>
+
+        <section id="sect184">
+            <pick class="money" count="9" />
+            <object objectId="dagger" />
+        </section>
+
+        <section id="sect185">
+            <meal />
+        </section>
+
+        <section id="sect187">
+            <choiceState section="sect123" set="disabled" />
+            <choiceState section="sect47" set="disabled" />
+
+            <test hasDiscipline="magi">
+                <choiceState section="sect123" set="enabled" />
+            </test>
+            <test hasDiscipline="alchemy">
+                <choiceState section="sect47" set="enabled" />
+            </test>
+        </section>
+
+        <section id="sect188">
+            <meal />
+        </section>
+
+        <section id="sect189">
+            <endurance count="-2" />
+            <test not="true" hasDiscipline="deliver">
+                <choiceState section="sect169" set="disabled" />
+            </test>
+            <test hasDiscipline="deliver">
+                <choiceState section="sect26" set="disabled" />
+            </test>
+        </section>
+
+        <section id="sect190">
+            <endurance count="-3" />
+            <message id="msg-drop-object" text="Drop two items of your choice from your Backpack Items list" />
+            <onInventoryEvent>
+                <test expression="[BACKPACK-ITEMS-CNT-ON-ACTIONCHART] == 0 || [BACKPACK-ITEMS-CNT-ON-SECTION] >= 2">
+                    <message id="msg-drop-object" op="hide" />
+                    <test hasDiscipline="alchemy">
+                        <choiceState section="sect158" set="enabled" />
+                        <choiceState section="sect247" set="disabled" />
+                    </test>
+                </test>
+                <test not="true" expression="[BACKPACK-ITEMS-CNT-ON-ACTIONCHART] == 0 || [BACKPACK-ITEMS-CNT-ON-SECTION] >= 2">
+                    <message id="msg-drop-object" op="show" />
+                    <choiceState section="all" set="disabled" />
+                </test>
+            </onInventoryEvent>
+        </section>
+
+        <section id="sect192">
+            <choiceState section="all" set="disabled" />
+
+            <combat combatSkillModifier="+2" />
+            <afterCombatTurn turn="1">
+                <combat combatSkillModifier="+0" />
+            </afterCombatTurn>
+
+            <afterCombats>
+                <test combatsWon="true">
+                    <choiceState section="all" set="enabled" />
+                </test>
+            </afterCombats>
+        </section>
+
+        <section id="sect194">
+            <choiceState section="sect22" set="disabled" />
+            <test hasDiscipline="anmlmstr">
+                <choiceState section="sect22" set="enabled" />
+                <choiceState section="sect173" set="disabled" />
+            </test>
+        </section>
+
+        <section id="sect197">
+            <choiceState section="all" set="disabled" />
+            <numberPicker 
+            text="Choose the number of Endurance Points you are prepared to deduct"
+            min="0" 
+            actionButton="Choose"
+            />
+            <numberPickerChoosed executeAtStart="true">
+                <numberPicker enabled="false" />
+                <endurance count="-[NUMBERPICKER]" />
+
+                <randomTable>
+                    <case from="0" to="2">
+                        <choiceState section="sect70" set="enabled" />
+                    </case>
+                    <case from="3" to="6">
+                        <choiceState section="sect246" set="enabled" />
+                    </case>
+                    <case from="7">
+                        <choiceState section="sect305" set="enabled" />
+                    </case>
+                </randomTable>
+
+                <randomTableIncrement increment="[NUMBERPICKER]" />
+            </numberPickerChoosed>
+        </section>
+
+        <section id="sect200">
+            <choiceState section="all" set="disabled" />
+            <test hasDiscipline="alchemy">
+                <choiceState section="sect3" set="enabled" />
+            </test>
+            <test hasDiscipline="element">
+                <choiceState section="sect147" set="enabled" />
+            </test>
+            <test canUseBow="true">
+                <choiceState section="sect10" set="enabled" />
+            </test>
+
+            <choiceState section="sect260" set="enabled" />
+        </section>
+
+
+
+
+
+
+
+        <section id="sect216">
+            <pick class="money" count="-2" />
+            <choiceState section="all" set="disabled" />
+            <randomTable>
+                <case from="0" to="4">
+                    <choiceState section="sect293" set="enabled" />
+                </case>
+                <case from="5">
+                    <choiceState section="sect194" set="enabled" />
+                </case>
+            </randomTable>
+
         </section>
     </sections>
 </mechanics>

--- a/www/data/mechanics-21.xml
+++ b/www/data/mechanics-21.xml
@@ -70,9 +70,7 @@
             </afterCombatTurn>
 
             <afterCombats>
-                <test combatsWon="true">
-                    <choiceState section="all" set="enabled" />
-                </test>
+                <choiceState section="all" set="enabled" />
             </afterCombats>
         </section>
 
@@ -142,17 +140,13 @@
 
         <section id="sect21">
             <choiceState section="all" set="disabled" />
-            <afterCombatTurn turn="2">
-                <test combatsWon="false">
-                    <choiceState section="sect13" set="enabled" />
-                </test>
-            </afterCombatTurn>
+            <combat eludeTurn="3" />
             <afterCombats>
-                <test combatsWon="true">
-                    <choiceState section="sect13" set="disabled" />
-                    <choiceState section="sect97" set="enabled" />
-                </test>
+                <choiceState section="sect97" set="enabled" />
             </afterCombats>
+            <afterElude>
+                <choiceState section="sect13" set="enabled" />
+            </afterElude>
         </section>
         
         <section id="sect22">
@@ -213,6 +207,9 @@
         </section>
 
         <section id="sect34">
+            <test expression="([MONEY]) &lt; 4">
+                <choiceState section="sect138" set="disabled" />
+            </test>
             <test expression="([MONEY]) &lt; 2">
                 <choiceState section="all" set="disabled" />
                 <message id="msg-drop-object" text="Drop one item of your choice to pay for a Standard room before continuing" />
@@ -260,10 +257,10 @@
         <section id="sect42">
             <choiceState section="all" set="disabled" />
             <randomTable>
-                <case from="0" to="4">
+                <case to="4">
                     <choiceState section="sect67" set="enabled" />
                 </case>
-                <case from="5" to="9">
+                <case from="5">
                     <choiceState section="sect205" set="enabled" />
                 </case>
             </randomTable>
@@ -283,10 +280,10 @@
         <section id="sect46">
             <choiceState section="all" set="disabled" />
             <randomTable>
-                <case from="0" to="4">
+                <case to="4">
                     <choiceState section="sect135" set="enabled" />
                 </case>
-                <case from="5" to="9">
+                <case from="5">
                     <choiceState section="sect4" set="enabled" />
                 </case>
             </randomTable>
@@ -325,7 +322,7 @@
                 <endurance count="-[NUMBERPICKER]" />
 
                 <randomTable>
-                    <case from="0" to="1">
+                    <case to="1">
                         <choiceState section="sect342" set="enabled" />
                     </case>
                     <case from="2" to="7">
@@ -359,7 +356,7 @@
             <choiceState section="all" set="disabled" />
 
             <randomTable>
-                <case from="0" to="1">
+                <case to="1">
                     <choiceState section="sect16" set="enabled" />
                 </case>
                 <case from="2">
@@ -551,7 +548,7 @@
             <choiceState section="all" set="disabled" />
 
             <randomTable>
-                <case from="0" to="3">
+                <case to="3">
                     <choiceState section="sect304" set="enabled" />
                 </case>
                 <case from="4">
@@ -579,9 +576,7 @@
 
             <combat immuneTurns="1" noMindblast="true" />
             <afterCombats>
-                <test combatsWon="true">
-                    <choiceState section="sect41" set="enabled" />
-                </test>
+                <choiceState section="sect41" set="enabled" />
             </afterCombats>
         </section>
 
@@ -615,7 +610,7 @@
             <choiceState section="all" set="disabled" />
 
             <randomTable>
-                <case from="0" to="4">
+                <case to="4">
                     <choiceState section="sect57" set="enabled" />
                 </case>
                 <case from="5">
@@ -724,7 +719,7 @@
             <choiceState section="all" set="disabled" />
 
             <randomTable>
-                <case from="0" to="2">
+                <case to="2">
                     <choiceState section="sect238" set="enabled" />
                 </case>
                 <case from="3" to="6">
@@ -772,18 +767,15 @@
         <section id="sect135">
             <choiceState section="sect334" set="disabled" />
             <afterCombats>
-                <test combatsWon="true">
-                    <choiceState section="sect334" set="enabled" />
-                </test>
+                <choiceState section="sect334" set="enabled" />
             </afterCombats>
         </section>
 
         <section id="sect136">
-            <pick class="arrow" count="-1" />
             <choiceState section="all" set="disabled" />
 
             <randomTable>
-                <case from="0" to="4">
+                <case to="4">
                     <choiceState section="sect320" set="enabled" />
                 </case>
                 <case from="5">
@@ -807,7 +799,7 @@
             <choiceState section="all" set="disabled" />
 
             <randomTable>
-                <case from="0" to="4">
+                <case to="4">
                     <choiceState section="sect330" set="enabled" />
                 </case>
                 <case from="5">
@@ -848,7 +840,7 @@
             <choiceState section="all" set="disabled" />
 
             <randomTable>
-                <case from="0" to="3">
+                <case to="3">
                     <choiceState section="sect335" set="enabled" />
                 </case>
                 <case from="4" to="6">
@@ -918,7 +910,7 @@
             <choiceState section="all" set="disabled" />
 
             <randomTable>
-                <case from="0" to="1">
+                <case to="1">
                     <choiceState section="sect276" set="enabled" />
                 </case>
                 <case from="2" to="6">
@@ -937,7 +929,7 @@
             <choiceState section="all" set="disabled" />
 
             <randomTable>
-                <case from="0" to="4">
+                <case to="4">
                     <choiceState section="sect218" set="enabled" />
                 </case>
                 <case from="5">
@@ -966,9 +958,7 @@
 
             <combat noMindblast="true" noKaiSurge="false" noPsiSurge="true" noKaiBlast="true" noKaiRay="true" combatSkillModifier="-3"/>
             <afterCombats>
-                <test combatsWon="true">
-                    <choiceState section="all" set="enabled" />
-                </test>
+                <choiceState section="all" set="enabled" />
             </afterCombats>
         </section>
 
@@ -1022,11 +1012,10 @@
         </section>
 
         <section id="sect170">
-            <pick class="arrow" count="-1" />
             <choiceState section="all" set="disabled" />
 
             <randomTable>
-                <case from="0" to="7">
+                <case to="7">
                     <choiceState section="sect348" set="enabled" />
                 </case>
                 <case from="8">
@@ -1052,7 +1041,7 @@
             <choiceState section="all" set="disabled" />
 
             <randomTable>
-                <case from="0" to="5">
+                <case to="5">
                     <choiceState section="sect231" set="enabled" />
                 </case>
                 <case from="6">
@@ -1179,9 +1168,7 @@
             </afterCombatTurn>
 
             <afterCombats>
-                <test combatsWon="true">
-                    <choiceState section="all" set="enabled" />
-                </test>
+                <choiceState section="all" set="enabled" />
             </afterCombats>
         </section>
 
@@ -1205,7 +1192,7 @@
                 <endurance count="-[NUMBERPICKER]" />
 
                 <randomTable>
-                    <case from="0" to="2">
+                    <case to="2">
                         <choiceState section="sect70" set="enabled" />
                     </case>
                     <case from="3" to="6">
@@ -1248,9 +1235,7 @@
             <combat noMindblast="true" />
 
             <afterCombats>
-                <test combatsWon="true">
-                    <choiceState section="all" set="enabled" />
-                </test>
+                <choiceState section="all" set="enabled" />
             </afterCombats>
         </section>
 
@@ -1287,9 +1272,7 @@
             <combat noWeapon="true" noMindblast="true" noKaiBlast="true" noKaiRay="true" noPsiSurge="true" />
 
             <afterCombats>
-                <test combatsWon="true">
-                    <choiceState section="all" set="enabled" />
-                </test>
+                <choiceState section="all" set="enabled" />
             </afterCombats>
         </section>
 
@@ -1305,7 +1288,7 @@
         <section id="sect212">
             <choiceState section="all" set="disabled" />
             <randomTable>
-                <case from="0" to="2">
+                <case to="2">
                     <choiceState section="sect238" set="enabled" />
                 </case>
                 <case from="3" to="6">
@@ -1339,7 +1322,7 @@
             <pick class="money" count="-2" />
             <choiceState section="all" set="disabled" />
             <randomTable>
-                <case from="0" to="4">
+                <case to="4">
                     <choiceState section="sect293" set="enabled" />
                 </case>
                 <case from="5">
@@ -1372,6 +1355,10 @@
             </test>
         </section>
 
+        <section id="sect222">
+            <pick class="arrow" count="-1" />
+        </section>
+
         <section id="sect224">
             <choiceState section="sect317" set="disabled" />
             <test hasDiscipline="herbmst">
@@ -1392,9 +1379,7 @@
             <choiceState section="all" set="disabled" />
             <combat noWeapon="1" />
             <afterCombats>
-                <test combatsWon="true">
-                    <choiceState section="all" set="enabled" />
-                </test>
+                <choiceState section="all" set="enabled" />
             </afterCombats>
         </section>
 
@@ -1447,10 +1432,9 @@
 
         <section id="sect244">
             <choiceState section="all" set="disabled" />
-            <pick class="arrow" count="-1"/>
 
             <randomTable>
-                <case from="0" to="5">
+                <case to="5">
                     <choiceState section="sect71" set="enabled" />
                 </case>
                 <case from="6">
@@ -1472,9 +1456,7 @@
             <choiceState section="all" set="disabled" />
             <combat noMindblast="true" />
             <afterCombats>
-                <test combatsWon="true">
-                    <choiceState section="all" set="enabled" />
-                </test>
+                <choiceState section="all" set="enabled" />
             </afterCombats>
         </section>
 
@@ -1519,16 +1501,14 @@
                 <combat combatSkillModifier="+0" />
             </afterCombatTurn>
             <afterCombats>
-                <test combatsWon="true">
-                    <choiceState section="all" set="enabled" />
-                </test>
+                <choiceState section="all" set="enabled" />
             </afterCombats>
         </section>
 
         <section id="sect260">
             <choiceState section="all" set="disabled" />
             <randomTable>
-                <case from="0" to="3">
+                <case to="3">
                     <choiceState section="sect120" set="enabled" />
                 </case>
                 <case from="4" to="6">
@@ -1556,9 +1536,7 @@
                 <combat combatSkillModifier="0"/>
             </afterCombatTurn>
             <afterCombats>
-                <test combatsWon="true">
-                    <choiceState section="all" set="enabled" />
-                </test>
+                <choiceState section="all" set="enabled" />
             </afterCombats>
         </section>
 
@@ -1569,7 +1547,7 @@
         <section id="sect263">
             <choiceState section="all" set="disabled" />
             <randomTable>
-                <case from="0" to="3">
+                <case to="3">
                     <choiceState section="sect335" set="enabled" />
                 </case>
                 <case from="4" to="6">
@@ -1586,9 +1564,7 @@
             <choiceState section="all" set="disabled" />
             <combat noMindblast="true "/>
             <afterCombats>
-                <test combatsWon="true">
-                    <choiceState section="all" set="enabled" />
-                </test>
+                <choiceState section="all" set="enabled" />
             </afterCombats>
         </section>
 
@@ -1608,7 +1584,7 @@
         <section id="sect270">
             <choiceState section="all" set="disabled" />
             <randomTable>
-                <case from="0" to="3">
+                <case to="3">
                     <choiceState section="sect112" set="enabled" />
                 </case>
                 <case from="4" to="7">
@@ -1651,16 +1627,14 @@
             <choiceState section="all" set="disabled" />
             <combat noMindblast="true "/>
             <afterCombats>
-                <test combatsWon="true">
-                    <choiceState section="all" set="enabled" />
-                </test>
+                <choiceState section="all" set="enabled" />
             </afterCombats>
         </section>
 
         <section id="sect280">
             <choiceState section="all" set="disabled" />
             <randomTable>
-                <case from="0" to="5">
+                <case to="5">
                     <choiceState section="sect231" set="enabled" />
                 </case>
                 <case from="6">
@@ -1681,7 +1655,7 @@
         <section id="sect283">
             <choiceState section="all" set="disabled" />
             <randomTable>
-                <case from="0" to="4">
+                <case to="4">
                     <choiceState section="sect218" set="enabled" />
                 </case>
                 <case from="5">
@@ -1709,7 +1683,7 @@
         <section id="sect292">
             <choiceState section="all" set="disabled" />
             <randomTable>
-                <case from="0" to="4">
+                <case to="4">
                     <choiceState section="sect44" set="enabled" />
                 </case>
                 <case from="5">
@@ -1722,13 +1696,14 @@
         </section>
 
         <section id="sect296">
+            <pick class="arrow" count="-1" />
             <endurance count="-1" />
         </section>
 
         <section id="sect297">
             <choiceState section="all" set="disabled" />
             <randomTable>
-                <case from="0" to="4">
+                <case to="4">
                     <choiceState section="sect248" set="enabled" />
                 </case>
                 <case from="5">
@@ -1756,13 +1731,263 @@
             <choiceState section="all" set="disabled" />
             <combat noMindblast="true" />
             <afterCombats>
-                <test combatsWon="true">
-                    <choiceState section="all" set="enabled" />
-                </test>
+                <choiceState section="all" set="enabled" />
             </afterCombats>
         </section>
 
+        <section id="sect302">
+            <test hasObject="temujunsring">
+                <choiceState section="sect143" set="disabled" />
+            </test>
+            <test not="true" hasObject="temujunsring">
+                <choiceState section="sect118" set="disabled" />
+            </test>
+        </section>
+
+        <section id="sect303">
+            <choiceState section="all" set="disabled" />
+            <combat noKaiBlast="true" noKaiRay="true" noMindblast="true" noPsiSurge="true" />
+            <afterCombats>
+                <choiceState section="all" set="enabled" />
+            </afterCombats>
+        </section>
+
+        <section id="sect304">
+            <death />
+        </section>
+
+        <section id="sect308">
+            <choiceState section="all" set="disabled" />
+            <randomTable>
+                <case to="4">
+                    <choiceState section="sect44" set="enabled" />
+                </case>
+                <case from="5">
+                    <choiceState section="sect261" set="enabled" />
+                </case>
+            </randomTable>
+            <test expression="[ENDURANCE] &lt;= 20">
+                <randomTableIncrement increment="-2" />
+            </test>
+        </section>
+
+        <section id="sect310">
+            <test not="true" hasObject="ironskull|kutyanemerald|siyencrown">
+                <choiceState section="sect54" set="disabled" />
+            </test>
+        </section>
+
+        <section id="sect314">
+            <meal />
+        </section>
+
+        <section id="sect315">
+            <test not="true" canUseBow="true">
+                <choiceState section="sect244" set="disabled" />
+            </test>
+        </section>
+
+        <section id="sect317">
+            <object objectId="cowana" index="0" />
+            <object objectId="cowana" index="1" />
+            <object objectId="cowana" index="2" />
+        </section>
+
+        <section id="sect319">
+            <endurance count="-4" />
+        </section>
+
+        <section id="sect320">
+            <pick class="arrow" count="-1" />
+            <death />
+        </section>
+
+        <section id="sect321">
+            <test expression="([MONEY]) &lt; 4">
+                <choiceState section="sect138" set="disabled" />
+            </test>
+            <test expression="([MONEY]) &lt; 2">
+                <choiceState section="all" set="disabled" />
+                <message id="msg-drop-object" text="Drop one item of your choice to pay for a Standard room before continuing" />
+
+                <onInventoryEvent>
+                    <test expression="[BACKPACK-ITEMS-CNT-ON-SECTION] > 0 || [WEAPON-ITEMS-CNT-ON-SECTION] > 0 || [SPECIAL-ITEMS-ON-SECTION] > 0">
+                        <message id="msg-drop-object" op="hide" />
+                        <choiceState section="sect216" set="enabled" />
+                    </test>
+                    <test expression="[BACKPACK-ITEMS-CNT-ON-SECTION] == 0 &amp;&amp; [WEAPON-ITEMS-CNT-ON-SECTION] == 0 &amp;&amp; [SPECIAL-ITEMS-ON-SECTION] == 0">
+                        <message id="msg-drop-object" op="show" />
+                        <choiceState section="sect216" set="disabled" />
+                    </test>
+                </onInventoryEvent>
+            </test>
+        </section>
+
         <section id="sect322">
+            <choiceState section="all" set="disabled" />
+            <randomTable>
+                <case to="3">
+                    <choiceState section="sect81" set="enabled" />
+                </case>
+                <case from="4" to="6">
+                    <choiceState section="sect154" set="enabled" />
+                </case>
+                <case from="7">
+                    <choiceState section="sect222" set="enabled" />
+                </case>
+            </randomTable>
+            <test hasWeaponskillWith="bow">
+                <randomTableIncrement increment="5" />
+            </test>
+        </section>
+
+        <section id="sect324">
+            <object objectId="laumspurpotion4" price="3" />
+            <object objectId="potiongallowbrush" price="3" />
+            <object objectId="potionofstrength" price="3" />
+        </section>
+
+        <section id="sect325">
+            <choiceState section="all" set="disabled" />
+            <randomTable>
+                <case to="4">
+                    <choiceState section="sect146" set="enabled" />
+                </case>
+                <case from="5">
+                    <choiceState section="sect252" set="enabled" />
+                </case>
+            </randomTable>
+        </section>
+
+        <section id="sect326">
+            <choiceState section="sect107" set="disabled" />
+            <test hasDiscipline="alchemy">
+                <choiceState section="sect107" set="enabled" />
+                <choiceState section="sect115" set="disabled" />
+            </test>
+        </section>
+
+        <section id="sect328">
+            <pick class="money" count="-10"/>
+        </section>
+
+        <section id="sect330">
+            <object objectId="meal" index="0" />
+            <object objectId="meal" index="1" />
+        </section>
+
+        <section id="sect331">
+            <choiceState section="all" set="disabled" />
+            <combat eludeTurn="3" />
+            <afterElude>
+                <choiceState section="sect13" set="enabled" />
+            </afterElude>
+            <afterCombats>
+                <choiceState section="sect97" set="enabled" />
+            </afterCombats>
+        </section>
+
+        <section id="sect333">
+            <test expression="[MONEY] &lt; 1">
+                <choiceState section="sect69" set="disabled" />
+            </test>
+            <choiceSelected section="sect69">
+                <pick class="money" count="-1" />
+            </choiceSelected>
+        </section>
+
+        <section id="sect335">
+            <choiceState section="sect158" set="disabled" />
+            <test hasDiscipline="alchemy">
+                <choiceState section="sect158" set="enabled" />
+                <choiceState section="sect247" set="disabled" />
+            </test>
+        </section>
+
+        <section id="sect337">
+            <choiceState section="all" set="disabled" />
+            <randomTable>
+                <case to="2">
+                    <choiceState section="sect32" set="enabled" />
+                </case>
+                <case from="3" to="4">
+                    <choiceState section="sect196" set="enabled" />
+                </case>
+                <case from="5" to="7">
+                    <choiceState section="sect256" set="enabled" />
+                </case>
+                <case from="8">
+                    <choiceState section="sect111" set="enabled" />
+                </case>
+            </randomTable>
+            <test hasDiscipline="pthmnshp">
+                <randomTableIncrement increment="3" />
+            </test>
+            <test hasDiscipline="gnosis">
+                <randomTableIncrement increment="1" />
+            </test>
+        </section>
+
+        <section id="sect338">
+            <test expression="[MONEY] == 0">
+                <message id="msg-drop-object" text="Drop one Backpack Item of your choice to pay the toll" />
+                <onInventoryEvent>
+                    <test expression="[BACKPACK-ITEMS-CNT-ON-SECTION] > 0">
+                        <message id="msg-drop-object" op="hide" />
+                        <choiceState section="all" set="enabled" />
+                    </test>
+                    <test expression="[BACKPACK-ITEMS-CNT-ON-SECTION] == 0">
+                        <message id="msg-drop-object" op="show" />
+                        <choiceState section="all" set="disabled" />
+                    </test>
+                </onInventoryEvent>
+            </test>
+            <test expression="[MONEY] > 0">
+                <pick class="money" count="-1"/>
+            </test>
+            <endurance count="-3" />
+        </section>
+
+        <section id="sect340">
+            <!-- TODO: Restore Weapons from ?? -->
+        </section>
+
+        <section id="sect341">
+            <endurance count="-4" />
+        </section>
+
+        <section id="sect342">
+            <endurance count="-15" />
+        </section>
+
+        <section id="sect345">
+            <choiceState section="all" set="disabled" />
+            <randomTable>
+                <case to="4">
+                    <choiceState section="sect266" set="enabled" />
+                </case>
+                <case from="5">
+                    <choiceState section="sect279" set="enabled" />
+                </case>
+            </randomTable>
+            <test hasWeaponskillWith="bow">
+                <randomTableIncrement increment="5" />
+            </test>
+            <test expression="[ENDURANCE] &lt;= 10">
+                <randomTableIncrement increment="-2" />
+            </test>
+        </section>
+
+        <section id="sect346">
+            <pick class="money" count="-1" />
+        </section>
+
+        <section id="sect347">
+            <endurance count="3" />
+            <object objectId="meal" />
+        </section>
+
+        <section id="sect348">
             <pick class="arrow" count="-1" />
         </section>
 
@@ -1770,6 +1995,8 @@
             <meal />
         </section>
 
-
+        <section id="sect350">
+            <message text="Congratulations! You have finished the last book of Kai Chronicles!" />
+        </section>
     </sections>
 </mechanics>

--- a/www/data/mechanics-21.xml
+++ b/www/data/mechanics-21.xml
@@ -140,7 +140,7 @@
 
         <section id="sect21">
             <choiceState section="all" set="disabled" />
-            <combat eludeTurn="3" />
+            <combat eludeTurn="3" properties="day" />
             <afterCombats>
                 <choiceState section="sect97" set="enabled" />
             </afterCombats>
@@ -191,6 +191,7 @@
         </section>
 
         <section id="sect31">
+            <combat properties="day" />
             <choiceState section="all" set="disabled" />
             <afterCombats>
                 <test not="true" expression="[COMBATSDURATION] > 4">
@@ -267,11 +268,11 @@
         </section>
 
         <section id="sect43">
-            <combat noMindblast="true" />
+            <combat noMindblast="true" properties="night" />
         </section>
 
         <section id="sect44">
-            <combat combatSkillModifier="+3" />
+            <combat combatSkillModifier="+3" properties="day" />
             <afterCombatTurn turn="2">
                 <combat combatSkillModifier="+0" />
             </afterCombatTurn>
@@ -305,7 +306,7 @@
         </section>
 
         <section id="sect50">
-            <combat noMindblast="true" noKaiSurge="true" noPsiSurge="true" noKaiBlast="true" noKaiRay="true" />
+            <combat properties="day" noMindblast="true" noKaiSurge="true" noPsiSurge="true" noKaiBlast="true" noKaiRay="true" />
         </section>
 
         <section id="sect51">
@@ -389,7 +390,7 @@
         </section>
 
         <section id="sect60">
-            <combat noMindblast="true" />
+            <combat noMindblast="true" properties="night" />
         </section>
 
         <section id="sect62">
@@ -574,7 +575,7 @@
         <section id="sect94">
             <choiceState section="all" set="disabled" />
 
-            <combat immuneTurns="1" noMindblast="true" />
+            <combat properties="day" immuneTurns="1" noMindblast="true" />
             <afterCombats>
                 <choiceState section="sect41" set="enabled" />
             </afterCombats>
@@ -691,7 +692,11 @@
         </section>
 
         <section id="sect120">
-            <combat noMindblast="true" />
+            <choiceState section="all" set="disabled" />
+            <combat noMindblast="true" properties="night" />
+            <afterCombats>
+                <choiceState section="all" set="enabled" />
+            </afterCombats>
         </section>
 
         <section id="sect121">
@@ -954,7 +959,7 @@
         <section id="sect162">
             <choiceState section="all" set="disabled" />
 
-            <combat noMindblast="true" noKaiSurge="false" noPsiSurge="true" noKaiBlast="true" noKaiRay="true" combatSkillModifier="-3"/>
+            <combat properties="day" noMindblast="true" noKaiSurge="false" noPsiSurge="true" noKaiBlast="true" noKaiRay="true" combatSkillModifier="-3"/>
             <afterCombats>
                 <choiceState section="all" set="enabled" />
             </afterCombats>
@@ -1158,7 +1163,7 @@
         <section id="sect192">
             <choiceState section="all" set="disabled" />
 
-            <combat combatSkillModifier="+2" />
+            <combat combatSkillModifier="+2" properties="day" />
             <afterCombatTurn turn="1">
                 <combat combatSkillModifier="+0" />
             </afterCombatTurn>
@@ -1228,7 +1233,7 @@
             <choiceState section="all" set="disabled" />
 
             <endurance count="-2" />
-            <combat noMindblast="true" />
+            <combat properties="day" noMindblast="true" />
 
             <afterCombats>
                 <choiceState section="all" set="enabled" />
@@ -1265,7 +1270,7 @@
 
         <section id="sect210">
             <choiceState section="all" set="disabled" />
-            <combat noWeapon="true" noMindblast="true" noKaiBlast="true" noKaiRay="true" noPsiSurge="true" />
+            <combat properties="day" noWeapon="true" noMindblast="true" noKaiBlast="true" noKaiRay="true" noPsiSurge="true" />
 
             <afterCombats>
                 <choiceState section="all" set="enabled" />
@@ -1373,7 +1378,7 @@
 
         <section id="sect230">
             <choiceState section="all" set="disabled" />
-            <combat noWeapon="1" />
+            <combat properties="day" noWeapon="1" />
             <afterCombats>
                 <choiceState section="all" set="enabled" />
             </afterCombats>
@@ -1448,7 +1453,7 @@
             <endurance count="-2" />
 
             <choiceState section="all" set="disabled" />
-            <combat noMindblast="true" />
+            <combat properties="day" noMindblast="true" />
             <afterCombats>
                 <choiceState section="all" set="enabled" />
             </afterCombats>
@@ -1490,7 +1495,7 @@
         <section id="sect257">
             <choiceState section="all" set="disabled" />
 
-            <combat combatSkillModifier="2" />
+            <combat properties="day" combatSkillModifier="2" />
             <afterCombatTurn turn="1">
                 <combat combatSkillModifier="+0" />
             </afterCombatTurn>

--- a/www/data/mechanics-21.xml
+++ b/www/data/mechanics-21.xml
@@ -53,7 +53,41 @@
             <object objectId="laumspurpotion4" />
             <object objectId="axe" />
 
-            <chooseEquipment text="Click on the Random Table link to get money before continuing" />
+            <randomTable index="1">
+                <case value="0">
+                    <pick objectId="spawnsmite"/>
+                </case>
+                <case value="1">
+                    <pick objectId="alema"/>
+                </case>
+                <case value="2">
+                    <pick objectId="magnara"/>
+                </case>
+                <case value="3">
+                    <pick objectId="sunstrike"/>
+                </case>
+                <case value="4">
+                    <pick objectId="kaistar"/>
+                </case>
+                <case value="5">
+                    <pick objectId="valiance"/>
+                </case>
+                <case value="6">
+                    <pick objectId="ulnarias"/>
+                </case>
+                <case value="7">
+                    <pick objectId="raumas"/>
+                </case>
+                <case value="8">
+                    <pick objectId="illuminatus"/>
+                </case>
+                <case value="9">
+                    <pick objectId="firefall"/>
+                </case>
+            </randomTable>
+
+            <chooseEquipment text="Click on the Random Table links to get money and a Kai Weapon before continuing" />
+
             <message text="You may take up to five of the following (all meals count as one object):" />
         </section>
 
@@ -65,6 +99,9 @@
             <choiceState section="all" set="disabled" />
 
             <combat noWeapon="true" />
+            <test currentWeapon="sunstrike">
+                <combat combatSkillModifier="+1"/>
+            </test>
             <afterCombatTurn turn="1">
                 <combat noWeapon="false" />
             </afterCombatTurn>
@@ -140,7 +177,10 @@
 
         <section id="sect21">
             <choiceState section="all" set="disabled" />
-            <combat eludeTurn="3" properties="day" />
+            <combat eludeTurn="3" />
+            <test currentWeapon="sunstrike">
+                <combat combatSkillModifier="+1"/>
+            </test>
             <afterCombats>
                 <choiceState section="sect97" set="enabled" />
             </afterCombats>
@@ -191,7 +231,10 @@
         </section>
 
         <section id="sect31">
-            <combat properties="day" />
+            <combat />
+            <test currentWeapon="sunstrike">
+                <combat combatSkillModifier="+1"/>
+            </test>
             <choiceState section="all" set="disabled" />
             <afterCombats>
                 <test not="true" expression="[COMBATSDURATION] > 4">
@@ -268,11 +311,17 @@
         </section>
 
         <section id="sect43">
-            <combat noMindblast="true" properties="night" />
+            <combat noMindblast="true" />
+            <test currentWeapon="kaistar">
+                <combat combatSkillModifier="+2"/>
+            </test>
         </section>
 
         <section id="sect44">
-            <combat combatSkillModifier="+3" properties="day" />
+            <combat combatSkillModifier="+3" />
+            <test currentWeapon="sunstrike">
+                <combat combatSkillModifier="+1"/>
+            </test>
             <afterCombatTurn turn="2">
                 <combat combatSkillModifier="+0" />
             </afterCombatTurn>
@@ -306,7 +355,7 @@
         </section>
 
         <section id="sect50">
-            <combat properties="day" noMindblast="true" noKaiSurge="true" noPsiSurge="true" noKaiBlast="true" noKaiRay="true" />
+            <combat noMindblast="true" noKaiSurge="true" noPsiSurge="true" noKaiBlast="true" noKaiRay="true" />
         </section>
 
         <section id="sect51">
@@ -390,7 +439,10 @@
         </section>
 
         <section id="sect60">
-            <combat noMindblast="true" properties="night" />
+            <combat noMindblast="true" />
+            <test currentWeapon="kaistar">
+                <combat combatSkillModifier="+2"/>
+            </test>
         </section>
 
         <section id="sect62">
@@ -575,7 +627,10 @@
         <section id="sect94">
             <choiceState section="all" set="disabled" />
 
-            <combat properties="day" immuneTurns="1" noMindblast="true" />
+            <combat immuneTurns="1" noMindblast="true" />
+            <test currentWeapon="kaistar">
+                <combat combatSkillModifier="+2"/>
+            </test>
             <afterCombats>
                 <choiceState section="sect41" set="enabled" />
             </afterCombats>
@@ -693,7 +748,10 @@
 
         <section id="sect120">
             <choiceState section="all" set="disabled" />
-            <combat noMindblast="true" properties="night" />
+            <combat noMindblast="true" />
+            <test currentWeapon="kaistar">
+                <combat combatSkillModifier="+2"/>
+            </test>
             <afterCombats>
                 <choiceState section="all" set="enabled" />
             </afterCombats>
@@ -959,7 +1017,10 @@
         <section id="sect162">
             <choiceState section="all" set="disabled" />
 
-            <combat properties="day" noMindblast="true" noKaiSurge="false" noPsiSurge="true" noKaiBlast="true" noKaiRay="true" combatSkillModifier="-3"/>
+            <combat noMindblast="true" noKaiSurge="false" noPsiSurge="true" noKaiBlast="true" noKaiRay="true" combatSkillModifier="-3"/>
+            <test currentWeapon="sunstrike">
+                <combat combatSkillModifier="+1"/>
+            </test>
             <afterCombats>
                 <choiceState section="all" set="enabled" />
             </afterCombats>
@@ -1163,7 +1224,10 @@
         <section id="sect192">
             <choiceState section="all" set="disabled" />
 
-            <combat combatSkillModifier="+2" properties="day" />
+            <combat combatSkillModifier="+2" />
+            <test currentWeapon="sunstrike">
+                <combat combatSkillModifier="+1"/>
+            </test>
             <afterCombatTurn turn="1">
                 <combat combatSkillModifier="+0" />
             </afterCombatTurn>
@@ -1233,7 +1297,10 @@
             <choiceState section="all" set="disabled" />
 
             <endurance count="-2" />
-            <combat properties="day" noMindblast="true" />
+            <combat noMindblast="true" />
+            <test currentWeapon="kaistar">
+                <combat combatSkillModifier="+2"/>
+            </test>
 
             <afterCombats>
                 <choiceState section="all" set="enabled" />
@@ -1270,8 +1337,10 @@
 
         <section id="sect210">
             <choiceState section="all" set="disabled" />
-            <combat properties="day" noWeapon="true" noMindblast="true" noKaiBlast="true" noKaiRay="true" noPsiSurge="true" />
-
+            <combat noMindblast="true" noKaiBlast="true" noKaiRay="true" noPsiSurge="true" />
+            <test currentWeapon="sunstrike">
+                <combat combatSkillModifier="+1"/>
+            </test>
             <afterCombats>
                 <choiceState section="all" set="enabled" />
             </afterCombats>
@@ -1378,7 +1447,10 @@
 
         <section id="sect230">
             <choiceState section="all" set="disabled" />
-            <combat properties="day" noWeapon="1" />
+            <combat noWeapon="1" />
+            <test currentWeapon="sunstrike">
+                <combat combatSkillModifier="+1"/>
+            </test>
             <afterCombats>
                 <choiceState section="all" set="enabled" />
             </afterCombats>
@@ -1453,7 +1525,10 @@
             <endurance count="-2" />
 
             <choiceState section="all" set="disabled" />
-            <combat properties="day" noMindblast="true" />
+            <combat noMindblast="true" />
+            <test currentWeapon="kaistar">
+                <combat combatSkillModifier="+2"/>
+            </test>
             <afterCombats>
                 <choiceState section="all" set="enabled" />
             </afterCombats>
@@ -1495,7 +1570,10 @@
         <section id="sect257">
             <choiceState section="all" set="disabled" />
 
-            <combat properties="day" combatSkillModifier="2" />
+            <combat combatSkillModifier="2" />
+            <test currentWeapon="sunstrike">
+                <combat combatSkillModifier="+1"/>
+            </test>
             <afterCombatTurn turn="1">
                 <combat combatSkillModifier="+0" />
             </afterCombatTurn>
@@ -1531,6 +1609,9 @@
         <section id="sect261">
             <choiceState section="all" set="disabled" />
             <combat combatSkillModifier="2"/>
+            <test currentWeapon="sunstrike">
+                <combat combatSkillModifier="+1"/>
+            </test>
             <afterCombatTurn turn="1">
                 <combat combatSkillModifier="0"/>
             </afterCombatTurn>
@@ -1561,7 +1642,10 @@
         <section id="sect266">
             <endurance count="-2" />
             <choiceState section="all" set="disabled" />
-            <combat noMindblast="true "/>
+            <combat noMindblast="true"/>
+            <test currentWeapon="kaistar">
+                <combat combatSkillModifier="+2"/>
+            </test>
             <afterCombats>
                 <choiceState section="all" set="enabled" />
             </afterCombats>
@@ -1624,7 +1708,10 @@
         <section id="sect279">
             <endurance count="-2" />
             <choiceState section="all" set="disabled" />
-            <combat noMindblast="true "/>
+            <combat noMindblast="true"/>
+            <test currentWeapon="kaistar">
+                <combat combatSkillModifier="+2"/>
+            </test>
             <afterCombats>
                 <choiceState section="all" set="enabled" />
             </afterCombats>
@@ -1729,6 +1816,9 @@
         <section id="sect300">
             <choiceState section="all" set="disabled" />
             <combat noMindblast="true" />
+            <test currentWeapon="kaistar">
+                <combat combatSkillModifier="+2"/>
+            </test>
             <afterCombats>
                 <choiceState section="all" set="enabled" />
             </afterCombats>
@@ -1746,6 +1836,9 @@
         <section id="sect303">
             <choiceState section="all" set="disabled" />
             <combat noKaiBlast="true" noKaiRay="true" noMindblast="true" noPsiSurge="true" />
+            <test currentWeapon="sunstrike">
+                <combat combatSkillModifier="+1"/>
+            </test>
             <afterCombats>
                 <choiceState section="all" set="enabled" />
             </afterCombats>
@@ -1876,6 +1969,9 @@
         <section id="sect331">
             <choiceState section="all" set="disabled" />
             <combat eludeTurn="3" />
+            <test currentWeapon="sunstrike">
+                <combat combatSkillModifier="+1"/>
+            </test>
             <afterElude>
                 <choiceState section="sect13" set="enabled" />
             </afterElude>

--- a/www/data/mechanics-21.xml
+++ b/www/data/mechanics-21.xml
@@ -11,6 +11,8 @@
             <drop objectId="map" />
             <!-- Restore Deliverance use each X days -->
             <restoreDeliveranceUse />
+            <!-- Reset Curing EP Used counter-->
+            <resetNewOrderCuringEPRestoredUse />
         </section>
 
         <section id="gamerulz">

--- a/www/data/mechanics-21.xml
+++ b/www/data/mechanics-21.xml
@@ -782,9 +782,7 @@
                     <choiceState section="sect296" set="enabled" />
                 </case>
             </randomTable>
-            <test hasWeaponskillWith="bow">
-                <randomTableIncrement increment="5" />
-            </test>
+            <randomTableIncrement increment="[BOWBONUS]" />
             <test expression="[ENDURANCE] &lt;= 15">
                 <randomTableIncrement increment="-1" />
             </test>
@@ -1022,9 +1020,7 @@
                     <choiceState section="sect59" set="enabled" />
                 </case>
             </randomTable>
-            <test hasWeaponskillWith="bow">
-                <randomTableIncrement increment="5" />
-            </test>
+            <randomTableIncrement increment="[BOWBONUS]" />
         </section>
 
         <section id="sect172">
@@ -1441,9 +1437,7 @@
                     <choiceState section="sect49" set="enabled" />
                 </case>
             </randomTable>
-            <test hasWeaponskillWith="bow">
-                <randomTableIncrement increment="5" />
-            </test>
+            <randomTableIncrement increment="[BOWBONUS]" />
         </section>
 
         <section id="sect246">
@@ -1836,9 +1830,7 @@
                     <choiceState section="sect222" set="enabled" />
                 </case>
             </randomTable>
-            <test hasWeaponskillWith="bow">
-                <randomTableIncrement increment="5" />
-            </test>
+            <randomTableIncrement increment="[BOWBONUS]" />
         </section>
 
         <section id="sect324">
@@ -1970,9 +1962,7 @@
                     <choiceState section="sect279" set="enabled" />
                 </case>
             </randomTable>
-            <test hasWeaponskillWith="bow">
-                <randomTableIncrement increment="5" />
-            </test>
+            <randomTableIncrement increment="[BOWBONUS]" />
             <test expression="[ENDURANCE] &lt;= 10">
                 <randomTableIncrement increment="-2" />
             </test>

--- a/www/data/mechanics-21.xml
+++ b/www/data/mechanics-21.xml
@@ -301,6 +301,10 @@
             </test>
         </section>
 
+        <section id="sect49">
+            <pick class="arrow" count="-1" />
+        </section>
+
         <section id="sect50">
             <combat noMindblast="true" noKaiSurge="true" noPsiSurge="true" noKaiBlast="true" noKaiRay="true" />
         </section>
@@ -442,6 +446,10 @@
             <endurance count="-10" />
         </section>
 
+        <section id="sect71">
+            <pick class="arrow" count="-1" />
+        </section>
+
         <section id="sect72">
             <choiceState section="sect345" set="disabled" />
             <test canUseBow="true">
@@ -490,6 +498,10 @@
                 <choiceState section="sect243" set="disabled" />
                 <choiceState section="sect225" set="enabled" />
             </test>
+        </section>
+
+        <section id="sect81">
+            <pick class="arrow" count="-1" />
         </section>
 
         <section id="sect82">
@@ -764,6 +776,7 @@
         </section>
 
         <section id="sect136">
+            <pick class="arrow" count="-1" />
             <choiceState section="all" set="disabled" />
 
             <randomTable>

--- a/www/data/mechanics-21.xml
+++ b/www/data/mechanics-21.xml
@@ -370,7 +370,21 @@
 
         <section id="sect51">
             <choiceState section="all" set="disabled" />
+            <randomTable>
+                <case to="1">
+                    <choiceState section="sect342" set="enabled" />
+                </case>
+                <case from="2" to="7">
+                    <choiceState section="sect15" set="enabled" />
+                </case>
+                <case from="8">
+                    <choiceState section="sect203" set="enabled" />
+                </case>
+            </randomTable>
 
+            <test hasDiscipline="hntmstry">
+                <randomTableIncrement increment="3" />
+            </test>
             <choiceState section="all" set="disabled" />
             <numberPicker 
             text="Choose the number of Endurance Points you are prepared to deduct"
@@ -380,23 +394,18 @@
             <numberPickerChoosed executeAtStart="true">
                 <numberPicker enabled="false" />
                 <endurance count="-[NUMBERPICKER]" />
+                <choiceState section="all" set="disabled" />
 
-                <randomTable>
-                    <case to="1">
-                        <choiceState section="sect342" set="enabled" />
-                    </case>
-                    <case from="2" to="7">
-                        <choiceState section="sect15" set="enabled" />
-                    </case>
-                    <case from="8">
-                        <choiceState section="sect203" set="enabled" />
-                    </case>
-                </randomTable>
-
-                <test hasDiscipline="hntmstry">
-                    <randomTableIncrement increment="3" />
-                </test>
                 <randomTableIncrement increment="[NUMBERPICKER]" />
+                <test expression="[RANDOM] + [NUMBERPICKER] &lt;= 1">
+                    <choiceState section="sect342" set="enabled" />
+                </test>
+                <test expression="[RANDOM] + [NUMBERPICKER] >= 2 &amp;&amp; [RANDOM] + [NUMBERPICKER] &lt;= 7">
+                    <choiceState section="sect15" set="enabled" />
+                </test>
+                <test expression="[RANDOM] + [NUMBERPICKER] >= 8">
+                    <choiceState section="sect203" set="enabled" />
+                </test>           
             </numberPickerChoosed>
         </section>
 
@@ -843,8 +852,8 @@
             <object objectId="dagger" />
             <pick class="money" count="20" />
             <endurance count="3" />
-            <object objectId="meal" />
-            <object objectId="meal" />
+            <object objectId="meal" index="0" />
+            <object objectId="meal" index="1" />
         </section>
 
         <section id="sect134">

--- a/www/data/mechanics.xsd
+++ b/www/data/mechanics.xsd
@@ -92,7 +92,7 @@
             <xs:documentation>Execute once only. Magnakai and later: Action Chart button to restore +X EP after Y days will available again.</xs:documentation>
         </xs:annotation>
     </xs:complexType>
-
+    
     <xs:complexType name="setDisciplines">
         <xs:annotation>
             <xs:documentation>Game setup: The player selects the Kai disciplines.</xs:documentation>
@@ -556,6 +556,16 @@
             <xs:annotation>
                 <xs:documentation>If false (true by default), don't allows usage of potions prior the combat</xs:documentation>
             </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="properties">
+            <xs:annotation>
+                <xs:documentation>Combat properties used by Kai Weapons to determine CS bonus</xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:pattern value = "(repitilian|undead|rock|day|night|magic|underwater|winged|underground|fire|\|)*"/>
+                </xs:restriction>
+            </xs:simpleType>
         </xs:attribute>
     </xs:complexType>
 

--- a/www/data/mechanics.xsd
+++ b/www/data/mechanics.xsd
@@ -359,7 +359,7 @@
 
     <xs:complexType name="object">
         <xs:annotation>
-            <xs:documentation>Make an object available on the section. The player will can pick / buy it.</xs:documentation>
+            <xs:documentation>Make an object available on the section. The player can pick / buy it.</xs:documentation>
         </xs:annotation>
         <xs:attribute name="objectId" type="xs:string" use="required">
             <xs:annotation>
@@ -1136,7 +1136,6 @@
             <xs:element name="book6sect340" type="specialsection_type" />
             <xs:element name="book9sect91" type="specialsection_type" />
             <xs:element name="book19sect304" type="specialsection_type" />
-
         </xs:choice>
     </xs:group>
 

--- a/www/data/mechanics.xsd
+++ b/www/data/mechanics.xsd
@@ -92,6 +92,12 @@
             <xs:documentation>Execute once only. Magnakai and later: Action Chart button to restore +X EP after Y days will available again.</xs:documentation>
         </xs:annotation>
     </xs:complexType>
+
+    <xs:complexType name="resetNewOrderCuringEPRestoredUse">
+        <xs:annotation>
+            <xs:documentation>Execute once only. New Order: Reset counter of EP restore by Curing, limited to 10 per book.</xs:documentation>
+        </xs:annotation>
+    </xs:complexType>
     
     <xs:complexType name="setDisciplines">
         <xs:annotation>
@@ -1083,6 +1089,7 @@
             <xs:element name="setSkills" type="setSkills" />
             <xs:element name="setKaiName" type="setKaiName" />
             <xs:element name="restoreDeliveranceUse" type="restoreDeliveranceUse" />
+            <xs:element name="resetNewOrderCuringEPRestoredUse" type="resetNewOrderCuringEPRestoredUse" />
             <xs:element name="setDisciplines" type="setDisciplines" />
             <xs:element name="pick" type="pick" />
             <xs:element name="randomTable" type="randomTable" />

--- a/www/data/mechanics.xsd
+++ b/www/data/mechanics.xsd
@@ -890,6 +890,7 @@
                 <xs:documentation>Identifies the objects to lose / restore (all by default) :</xs:documentation>
                 <xs:documentation>- all: The backpack content, the backpack itself, special items, meals and money</xs:documentation>
                 <xs:documentation>- weaponlike: Weapons and weapon-like special items</xs:documentation>
+                <xs:documentation>- bow: Bow weapons</xs:documentation>
                 <xs:documentation>- allobjects: The backpack content, special items and meals</xs:documentation>
             </xs:annotation>
             <xs:simpleType>

--- a/www/data/mechanics.xsd
+++ b/www/data/mechanics.xsd
@@ -81,6 +81,12 @@
         </xs:annotation>
     </xs:complexType>
 
+    <xs:complexType name="setKaiName">
+        <xs:annotation>
+            <xs:documentation>Game setup: The player selects their Kai Name.</xs:documentation>
+        </xs:annotation>
+    </xs:complexType>
+    
     <xs:complexType name="restoreDeliveranceUse">
         <xs:annotation>
             <xs:documentation>Execute once only. Magnakai and later: Action Chart button to restore +X EP after Y days will available again.</xs:documentation>
@@ -218,7 +224,7 @@
             </xs:annotation>
             <xs:simpleType>
                 <xs:restriction base="xs:string">
-                    <xs:pattern value = "(sixthsns|camflage|tracking|mindomtr|anmlknsp|healing|hunting|mindshld|mndblst|wepnskll|wpnmstry|anmlctrl|curing|invsblty|psisurge|psiscrn|nexus|dvnation|anmlmstr|deliver|assimila|kaisurge|kaiscrn|gnosis|magi|alchemy|hntmstry|pthmnshp|\|)*"/>
+                    <xs:pattern value = "(sixthsns|camflage|tracking|mindomtr|anmlknsp|healing|hunting|mindshld|mndblst|wepnskll|wpnmstry|anmlctrl|curing|invsblty|psisurge|psiscrn|nexus|dvnation|anmlmstr|deliver|assimila|kaisurge|kaiscrn|gnosis|magi|alchemy|hntmstry|pthmnshp|astrolgy|herbmst|element|bardsman|\|)*"/>
                 </xs:restriction>
             </xs:simpleType>
         </xs:attribute>
@@ -1062,6 +1068,7 @@
         <xs:choice>
             <xs:element name="tag" type="tag" />
             <xs:element name="setSkills" type="setSkills" />
+            <xs:element name="setKaiName" type="setKaiName" />
             <xs:element name="restoreDeliveranceUse" type="restoreDeliveranceUse" />
             <xs:element name="setDisciplines" type="setDisciplines" />
             <xs:element name="pick" type="pick" />

--- a/www/data/mechanics.xsd
+++ b/www/data/mechanics.xsd
@@ -855,6 +855,8 @@
         <xs:attribute name="class" type="xs:string">
             <xs:annotation>
                 <xs:documentation>special : You can sell any Special Item object</xs:documentation>
+                <xs:documentation>weapon : You can sell any Weapon object</xs:documentation>
+                <xs:documentation>object : You can sell any Backpack Item object</xs:documentation>
             </xs:annotation>
         </xs:attribute>
         <xs:attribute name="except" type="xs:string">

--- a/www/data/objects.xml
+++ b/www/data/objects.xml
@@ -3,8 +3,7 @@
 <object-mechanics  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/cracrayol/kaichronicles/master/www/data/objects.xsd">
 
     <weapons>
-        <!-- WEAPONS ON KAI / MAGNAKAI SERIE BOOKS -->
-
+        <!-- WEAPONS ON KAI / MAGNAKAI SERIES BOOKS -->
         <weapon id="axe">
             <name>Axe</name>
             <image book="1|9" name="axe.png" />
@@ -814,6 +813,16 @@
         <special id="bluediamond">
             <name>Blue Diamond</name>
             <description>A radiant gem the size of a walnut.</description>
+        </special>
+
+        <!-- BOOK 21 -->
+
+        <special id="moonstone">
+            <name>Moonstone</name>
+        </special>
+
+        <special id="ironskull">
+            <name>Iron Skull</name>
         </special>
 
     </specials>
@@ -1648,6 +1657,16 @@
 
         <object id="shamathpotion">
             <name>Shamath’s potion</name>
+        </object>
+
+        <!-- BOOK 21 -->
+        <object id="flute">
+            <name>Flute</name>
+            <image book="21" name="flute.png" />
+        </object>
+
+        <object id="cowana">
+            <name>Cowana Herb</name>
         </object>
 
         <!-- OTHERS -->

--- a/www/data/objects.xml
+++ b/www/data/objects.xml
@@ -817,6 +817,56 @@
 
         <!-- BOOK 21 -->
 
+        <special id="spawnsmite" weaponType="axe" incompatibleWith="alema|magnara|sunstrike|kaistar|valiance|ulnarias|raumas|illuminatus|firefall">
+            <name>Spawnsmite</name>
+            <effect class="combatSkill" increment="5" />
+        </special>
+
+        <special id="alema" weaponType="axe" incompatibleWith="spawnsmite|magnara|sunstrike|kaistar|valiance|ulnarias|raumas|illuminatus|firefall">
+            <name>Alema</name>
+            <effect class="combatSkill" increment="5" />
+        </special>
+
+        <special id="magnara" weaponType="axe" incompatibleWith="spawnsmite|alema|sunstrike|kaistar|valiance|ulnarias|raumas|illuminatus|firefall">
+            <name>Magnara</name>
+            <effect class="combatSkill" increment="5" />
+        </special>
+
+        <special id="sunstrike" weaponType="sword" incompatibleWith="spawnsmite|magnara|alema|kaistar|valiance|ulnarias|raumas|illuminatus|firefall">
+            <name>Sunstrike</name>
+            <effect class="combatSkill" increment="5" />
+        </special>
+
+        <special id="kaistar" weaponType="sword" incompatibleWith="spawnsmite|magnara|sunstrike|alema|valiance|ulnarias|raumas|illuminatus|firefall">
+            <name>Kaistar</name>
+            <effect class="combatSkill" increment="5" />
+        </special>
+
+        <special id="valiance" weaponType="sword" incompatibleWith="spawnsmite|magnara|sunstrike|kaistar|alema|ulnarias|raumas|illuminatus|firefall">
+            <name>Valiance</name>
+            <effect class="combatSkill" increment="5" />
+        </special>
+
+        <special id="ulnarias" weaponType="sword" incompatibleWith="spawnsmite|magnara|sunstrike|kaistar|valiance|alema|raumas|illuminatus|firefall">
+            <name>Ulnarias</name>
+            <effect class="combatSkill" increment="5" />
+        </special>
+
+        <special id="raumas" weaponType="broadsword" incompatibleWith="spawnsmite|magnara|sunstrike|kaistar|valiance|ulnarias|alema|illuminatus|firefall">
+            <name>Raumas</name>
+            <effect class="combatSkill" increment="5" />
+        </special>
+
+        <special id="illuminatus" weaponType="broadsword" incompatibleWith="spawnsmite|magnara|sunstrike|kaistar|valiance|ulnarias|raumas|alema|firefall">
+            <name>Illuminatus</name>
+            <effect class="combatSkill" increment="5" />
+        </special>
+
+        <special id="firefall" weaponType="broadsword" incompatibleWith="spawnsmite|magnara|sunstrike|kaistar|valiance|ulnarias|raumas|illuminatus|alema">
+            <name>Firefall</name>
+            <effect class="combatSkill" increment="5" />
+        </special>
+
         <special id="moonstone">
             <name>Moonstone</name>
         </special>

--- a/www/data/objects.xml
+++ b/www/data/objects.xml
@@ -819,51 +819,61 @@
 
         <special id="spawnsmite" weaponType="axe" incompatibleWith="alema|magnara|sunstrike|kaistar|valiance|ulnarias|raumas|illuminatus|firefall">
             <name>Spawnsmite</name>
+            <description>+6CS versus reptilian enemies</description>
             <effect class="combatSkill" increment="5" />
         </special>
 
         <special id="alema" weaponType="axe" incompatibleWith="spawnsmite|magnara|sunstrike|kaistar|valiance|ulnarias|raumas|illuminatus|firefall">
             <name>Alema</name>
+            <description>+7CS versus undead enemies</description>
             <effect class="combatSkill" increment="5" />
         </special>
 
         <special id="magnara" weaponType="axe" incompatibleWith="spawnsmite|alema|sunstrike|kaistar|valiance|ulnarias|raumas|illuminatus|firefall">
             <name>Magnara</name>
+            <description>+8CS versus rock or stone</description>
             <effect class="combatSkill" increment="5" />
         </special>
 
         <special id="sunstrike" weaponType="sword" incompatibleWith="spawnsmite|magnara|alema|kaistar|valiance|ulnarias|raumas|illuminatus|firefall">
             <name>Sunstrike</name>
+            <description>+6CS when used in daylight</description>
             <effect class="combatSkill" increment="5" />
         </special>
 
         <special id="kaistar" weaponType="sword" incompatibleWith="spawnsmite|magnara|sunstrike|alema|valiance|ulnarias|raumas|illuminatus|firefall">
             <name>Kaistar</name>
+            <description>+7CS when used at night</description>
             <effect class="combatSkill" increment="5" />
         </special>
 
         <special id="valiance" weaponType="sword" incompatibleWith="spawnsmite|magnara|sunstrike|kaistar|alema|ulnarias|raumas|illuminatus|firefall">
             <name>Valiance</name>
+            <description>+8CS when used against magicians or creatures born of magic</description>
             <effect class="combatSkill" increment="5" />
         </special>
 
         <special id="ulnarias" weaponType="sword" incompatibleWith="spawnsmite|magnara|sunstrike|kaistar|valiance|alema|raumas|illuminatus|firefall">
             <name>Ulnarias</name>
+            <description>+9CS when used underwater</description>
             <effect class="combatSkill" increment="5" />
         </special>
 
         <special id="raumas" weaponType="broadsword" incompatibleWith="spawnsmite|magnara|sunstrike|kaistar|valiance|ulnarias|alema|illuminatus|firefall">
             <name>Raumas</name>
+            <description>+6CS versus winged enemies</description>
             <effect class="combatSkill" increment="5" />
         </special>
 
         <special id="illuminatus" weaponType="broadsword" incompatibleWith="spawnsmite|magnara|sunstrike|kaistar|valiance|ulnarias|raumas|alema|firefall">
             <name>Illuminatus</name>
+            <description>+7CS when used underground</description>
             <effect class="combatSkill" increment="5" />
         </special>
 
         <special id="firefall" weaponType="broadsword" incompatibleWith="spawnsmite|magnara|sunstrike|kaistar|valiance|ulnarias|raumas|illuminatus|alema">
             <name>Firefall</name>
+            <description>+8CS versus fire-emitting enemies</description>
             <effect class="combatSkill" increment="5" />
         </special>
 

--- a/www/data/objects.xml
+++ b/www/data/objects.xml
@@ -1693,6 +1693,8 @@
 
         <object id="cowana">
             <name>Cowana Herb</name>
+            <description>Each dose of Cowana will restore 4 ENDURANCE points to your total when swallowed after combat.</description>
+            <usage class="endurance" increment="4" />
         </object>
 
         <object id="scentedoil">

--- a/www/data/objects.xml
+++ b/www/data/objects.xml
@@ -825,6 +825,18 @@
             <name>Iron Skull</name>
         </special>
 
+        <special id="temujunsring">
+            <name>Temujun’s Ring</name>
+        </special>
+
+        <special id="siyencrown">
+            <name>Siyen Crown</name>
+        </special>
+
+        <special id="kutyanemerald">
+            <name>Kutyan Emerald</name>
+        </special>
+
     </specials>
 
     <objects>
@@ -1664,9 +1676,47 @@
             <name>Flute</name>
             <image book="21" name="flute.png" />
         </object>
+        
+        <object id="mustowpotion">
+            <name>Mustow Potion</name>
+            <description>
+                Creates a foul choking gas when released into the air
+            </description>
+        </object>
+
+        <object id="sebarispotion">
+            <name>Sebaris Potion</name>
+            <description>
+                Purifies contaminated water
+            </description>
+        </object>
 
         <object id="cowana">
             <name>Cowana Herb</name>
+        </object>
+
+        <object id="scentedoil">
+            <name>Scented Oil</name>
+        </object>
+
+        <object id="candle">
+            <name>Candle</name>
+        </object>
+
+        <object id="slippers">
+            <name>Slippers</name>
+        </object>
+
+        <object id="coppercup">
+            <name>Copper Cup</name>
+        </object>
+
+        <object id="lyre">
+            <name>Lyre</name>
+        </object>
+
+        <object id="ballofchalk">
+            <name>Ball of Chalk</name>
         </object>
 
         <!-- OTHERS -->

--- a/www/index.html
+++ b/www/index.html
@@ -47,10 +47,8 @@
           <a class="navbar-brand hidden-xs hidden-sm" href="#mainMenu" id="template-title">
             Kai Chronicles
           </a>
-          <p class="navbar-text" id="template-kaiNameHeader">
-            <span id="template-kaiName"></span>
-          </p>
           <p class="navbar-text" id="template-statistics">
+              <span id="template-kaiName"></span>
               <span data-translation="CS">C.S.</span>: 
               <span id="template-combatSkill">99</span>
               <span data-translation="E">E.</span>: 

--- a/www/index.html
+++ b/www/index.html
@@ -47,6 +47,9 @@
           <a class="navbar-brand hidden-xs hidden-sm" href="#mainMenu" id="template-title">
             Kai Chronicles
           </a>
+          <p class="navbar-text" id="template-kaiNameHeader">
+            <span id="template-kaiName"></span>
+          </p>
           <p class="navbar-text" id="template-statistics">
               <span data-translation="CS">C.S.</span>: 
               <span id="template-combatSkill">99</span>

--- a/www/views/about.html
+++ b/www/views/about.html
@@ -13,7 +13,7 @@
 
 <h4 data-translation="distribution">Distribution</h4>
 <p data-translation="distributionInfo">
-    Book distributed by the <a href="https://www.projectaon.org">Project Aon</a>, 
+    Book distributed by <a href="https://www.projectaon.org">Project Aon</a>, 
     under the <a href="#projectAonLicense">Project Aon License</a>.
 </p>
 
@@ -35,10 +35,7 @@
     Source code is under GPL license.
     It contains parts of code taken from Lone Wolf Adventures, created by Liquid State Limited.
 </p>
-<p data-translation="webPlay">
-    You can play to this game with a web browser at 
-    <a class="breakable" href="https://www.projectaon.org/staff/toni">https://www.projectaon.org/staff/toni</a>.
-</p>
+
 <p>
     Source code available at:<br/>
     <a class="breakable" href="https://github.com/cracrayol/kaichronicles">

--- a/www/views/actionChart.html
+++ b/www/views/actionChart.html
@@ -85,5 +85,27 @@
     </tbody>
 </table> 
 
+<p id="kaiWeapon">
+  <h3><span data-translation="kaiWeapon">Kai Weapon</span></h3>
+  <table class="table table-striped table-bordered" id="achart-kaiWeapon">
+      <tbody>
+        <tr>
+          <td colspan="2">
+            Weapon Name: <span id="kaiWeaponName"></span>
+          </td>
+        </tr>
+        <tr>
+          <td >Weapon Type: <span id="kaiWeaponType"></span></td>
+          <td >Bonus: <span id="kaiWeaponBonus"></span></td>
+        </tr>
+        <tr>
+          <td colspan="2">
+            Unique Properties: <span id="kaiWeaponProperties"></span>
+          </td>
+        </tr>
+      </tbody>
+  </table> 
+</p>
+
 <h3 data-translation="annotations">Annotations</h3>
-<textarea class="form-control" rows="10" id="achart-annotations"></textarea>
+<textarea title="Annotations" class="form-control" rows="10" id="achart-annotations"></textarea>

--- a/www/views/mainMenu.html
+++ b/www/views/mainMenu.html
@@ -6,7 +6,7 @@
     </div>
     <b>v1.15.2</b><br/>
     <span data-translation="appInfo">
-        This is a player for Lone Wolf game books 1 to 20.
+        This is a player for Lone Wolf game books 1 to 21.
     </span>
 </p>
 <div id="menu-webinfo">

--- a/www/views/mechanicsEngine.html
+++ b/www/views/mechanicsEngine.html
@@ -85,6 +85,7 @@
                 Message goes here
             </b>
         </div>
+
         <!-- Max. Special Items, starting from book 8 -->
         <div class="well" id="mechanics-chooseEquipment-maxSpecials">
             <b data-translation="maxSpecialItems">

--- a/www/views/mechanicsEngine.html
+++ b/www/views/mechanicsEngine.html
@@ -20,6 +20,24 @@
         </p>
     </div>
 
+    <!-- Set Kai name -->
+    <div class="well" id="mechanics-setKaiName">
+        <p id="mechanics-detFirstName">
+            <span data-translation="chooseNumberOn">Choose a number on the</span> 
+            <a href="#" class="random action" id="mechanics-chooseFirstName" data-translation="randomTable">
+                Random number table
+            </a>
+            <span data-translation="determineFirstName">to determine your First Name</span>.
+        </p>
+        <p id="mechanics-detLastName">
+            <span data-translation="chooseNumberOn">Choose a number on the</span> 
+            <a href="#" class="random action" id="mechanics-chooseLastName" data-translation="randomTable">
+                Random number table
+            </a> 
+            <span data-translation="determineLastName">to determine your Last Name</span>.
+        </p>
+    </div>
+
     <!-- Select kai disciplines -->
     <div class="well" id="mechanics-setDisciplines">
         <div class="checkbox">

--- a/www/views/mechanicsEngine.html
+++ b/www/views/mechanicsEngine.html
@@ -22,20 +22,31 @@
 
     <!-- Set Kai name -->
     <div class="well" id="mechanics-setKaiName">
-        <p id="mechanics-detFirstName">
-            <span data-translation="chooseNumberOn">Choose a number on the</span> 
-            <a href="#" class="random action" id="mechanics-chooseFirstName" data-translation="randomTable">
-                Random number table
-            </a>
-            <span data-translation="determineFirstName">to determine your First Name</span>.
-        </p>
-        <p id="mechanics-detLastName">
-            <span data-translation="chooseNumberOn">Choose a number on the</span> 
-            <a href="#" class="random action" id="mechanics-chooseLastName" data-translation="randomTable">
-                Random number table
-            </a> 
-            <span data-translation="determineLastName">to determine your Last Name</span>.
-        </p>
+        <div id="mechanics-existingKaiName">
+            <span data-translation="yourKaiName">Your Kai Name:</span>
+            <span id="kaiName"></span>
+        </div>
+        <div id="mechanics-setNames">
+            <p>
+                <span data-translation="enterKaiNameHere">Enter your Kai name here:</span>
+                <input class="form-control" id="mechanics-customKaiName" title="Custom Kai Name" type="text" />
+                <span>or</span>
+            </p>
+            <p id="mechanics-detFirstName">
+                <span data-translation="chooseNumberOn">Choose a number on the</span> 
+                <a href="#" class="random action" id="mechanics-chooseFirstName" data-translation="randomTable">
+                    Random number table
+                </a>
+                <span data-translation="determineFirstName">to determine your First Name</span>.
+            </p>
+            <p id="mechanics-detLastName">
+                <span data-translation="chooseNumberOn">Choose a number on the</span> 
+                <a href="#" class="random action" id="mechanics-chooseLastName" data-translation="randomTable">
+                    Random number table
+                </a> 
+                <span data-translation="determineLastName">to determine your Last Name</span>.
+            </p>
+        </div>
     </div>
 
     <!-- Select kai disciplines -->
@@ -454,26 +465,26 @@
     <!-- Show info about writting in Action Chart -->
     <div class="well" id="mechanics-actionChartInfo" data-translation="actionchartinfo">
         <p>
-            Following sections explain how to play with the printed books. This application is an adaptation of the game books, 
+            The following sections explain how to play with the printed books. This application is an adaptation of the game books, 
             and you will not need to write by hand on the Action Chart (except on the "Annotations" field). The
             application tries to do all the game accounting.
         </p>
         <p>
             On the Action Chart there are functions to check your stats and to handle your inventory (use or drop 
-            objects, change current weapon, ...).
+            objects, change current weapon, etc.).
         </p>
         <p>
-            Each time you see a blue bold text like this "<a class="random action">Some text</a>" into the book text, 
+            Each time you see a blue bold text like this "<a class="random action">Some text</a>" in the book text, 
             it's an action. Usually this action will be get a number from the Random Number Table. 
-            Click on it to do that action.
+            Click on it to perform that action.
         </p>
         <p>
-            Non bold blue text like this "<a>Some text</a>" are links to other places (to the Action Chart, or the map,...).
+            Non-bold blue text like this "<a>Some text</a>" are links to other places (to the Action Chart, or the map, etc.).
             If you click on it you will go there.
         </p>
         <p>
-            At this page bottom there are two links to choose your Combat Skill and Endurance Points. Click on them 
-            before continue to the next section.
+            If you have not played a previous book, at the bottom of this page there are two links to choose your Combat Skill and Endurance Points.
+            Click on them before continuing to the next section.
         </p>
     </div>
 


### PR DESCRIPTION
Fully playable.
Some minor items remain open:

1. Ability to manually select the Kai Weapon from a list.  At the moment, only random choice allowed
2. Limiting per-section curing (+1 per section) to EP lost due to combat.  Not even sure how to track this properly yet (ie. if I lost EP due to section effect and combat, then I use Laumspur, how much EP is left that can be accounted to combat?)

Otherwise, everything seems to work as described in the New Order rules.  According to the rules, New Order disciplines seem weaker than those in other books (limited Curing, Grand Huntmastery required to avoid meals, etc.). 

Resolves #30  (at least the first book)